### PR TITLE
Count the amount of free slots across MainInventory and ExtendedInventory

### DIFF
--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -39,6 +39,15 @@ impl Inventory {
         None
     }
 
+    pub fn count_free_slots(&self) -> usize {
+        let bag_free_slots = self.bag.iter().filter(|slot| slot.is_none()).count();
+        let fortress_chest_free_slots = self
+            .fortress_chest
+            .as_ref()
+            .map_or(0, |chest| chest.iter().filter(|slot| slot.is_none()).count());
+        bag_free_slots + fortress_chest_free_slots
+    }
+
     pub(crate) fn update_fortress_chest(
         &mut self,
         data: &[i64],


### PR DESCRIPTION
Instead of just providing the index of a free slot it sometimes is necessary to know the amount of free slots available, for example when doing barehanded attacks for DailyTasks. Probably a very "hacky" solution..