### PR TITLE
fix parsing problems for hall of fame page with empty entries

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -569,6 +569,11 @@ impl GameState {
                 "Ranklistplayer" => {
                     self.hall_of_fames.players.clear();
                     for player in val.as_str().trim_matches(';').split(';') {
+                        // Stop parsing once we receive an empty player
+                        if player.ends_with(",,,0,0,0,") {
+                            break;
+                        }
+                        
                         match HallOfFamePlayer::parse(player) {
                             Ok(x) => {
                                 self.hall_of_fames.players.push(x);


### PR DESCRIPTION
this can for example happen when fetching the very last page of a server previously this would give warnings and now just stops parsing

example response for the last page:
```json
{"Ranklistplayer": "13006,ち丹メメメモ尺,,1,0,6,;13007,Julas4571,,1,0,4,;13008,VALERIA,,1,0,5,;13009,Mega,,1,0,10,;13010,Stacholski,,1,0,9,;13011,Navarro,,10,0,6,;13012,Geniowska,,1,0,1,;13013,cnnr,,1,0,4,;13014,Omel,,1,0,2,;13015,M4rbi,,14,0,3,;13016,Arxus,,1,0,3,;13017,Latmanen,,1,0,3,;13018,Dante Alighieri,,1,0,7,;13019,Sameubek Jurokis,,1,0,7,;13020,Hvbson,,10,0,2,;13021,Gigassassin,FridgeIndustries,26,0,4,;13022,vostra,,5,0,2,;13023,ViTrEx,,11,0,9,;13024,IceMage,,4,0,2,;13025,Gargulec12,,11,0,2,;13026,Kitty,,1,0,1,;13027,The Wall,,1,0,1,;13028,,,0,0,0,;13029,,,0,0,0,;13030,,,0,0,0,;13031,,,0,0,0,;13032,,,0,0,0,;13033,,,0,0,0,;13034,,,0,0,0,;13035,,,0,0,0,;13036,,,0,0,0,;13037,,,0,0,0,;13038,,,0,0,0,;13039,,,0,0,0,;13040,,,0,0,0,;13041,,,0,0,0,;13042,,,0,0,0,;13043,,,0,0,0,;13044,,,0,0,0,;13045,,,0,0,0,;13046,,,0,0,0,;13047,,,0,0,0,;13048,,,0,0,0,;13049,,,0,0,0,;13050,,,0,0,0,;13051,,,0,0,0,;13052,,,0,0,0,;13053,,,0,0,0,;13054,,,0,0,0,;13055,,,0,0,0,;"}
```

since there are only 13027 players the rest of the page is filled with empty players which would cause this warning before:
```
Invalid hof class: 0 - ["13028", "", "", "0", "0", "0", ""]
```