### PR TITLE
fix edge case when unlocking the fortress

### DIFF
--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -51,8 +51,8 @@ pub struct Fortress {
     pub upgrades: u16,
     /// The honor you have in the fortress Hall of Fame
     pub honor: u32,
-    /// The rank you have in the fortress Hall of Fame
-    pub rank: u32,
+    /// The rank you have in the fortress Hall of Fame if you have any
+    pub rank: Option<u32>,
 
     /// Information about searching for gems
     pub gem_search: FortressAction<GemType>,
@@ -328,7 +328,13 @@ impl Fortress {
 
         self.upgrades = data.csiget(581, "fortress lvl", 0)?;
         self.honor = data.csiget(582, "fortress honor", 0)?;
-        self.rank = data.csiget(583, "fortress rank", 0)?;
+        let fortress_rank: i64 = data.csiget(583, "fortress rank", 0)?;
+        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        if fortress_rank > 0 {
+            self.rank = Some(fortress_rank as u32);
+        } else {
+            self.rank = None;
+        }
 
         self.gem_search.start =
             data.cstget(595, "gem search start", server_time)?;

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1451,10 +1451,8 @@ impl GameState {
                 self.guild = None;
             }
         }
-        if let Some(t) = &self.fortress {
-            if t.upgrades == 0 {
-                self.fortress = None;
-            }
+        if self.fortress.is_some() && self.character.level < 25 {
+            self.fortress = None;
         }
         if let Some(t) = &self.underworld {
             if t.honor == 0 {


### PR DESCRIPTION
if you have just reached level 25 but not build anything the fortress is technically unlocked but you still don't have a rank

this commit fixes that by making the rank an optional and correcting the logic for when you have the fortress unlocked