### PR TITLE
otherplayer soldier advice

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -453,10 +453,7 @@ impl GameState {
                     other_player
                         .get_or_insert_with(Default::default)
                         .soldier_advice =
-                        match val.into::<i16>("other player soldier advice")? {
-                            ..=-1 => None,
-                            x => Some(x.try_into().unwrap_or(1)),
-                        };
+                        val.into::<u16>("other player soldier advice").ok();
                 }
                 "owngroupdescription" => self
                     .guild

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -450,7 +450,13 @@ impl GameState {
                         )?;
                 }
                 "soldieradvice" => {
-                    // I think they removed this
+                    other_player
+                        .get_or_insert_with(Default::default)
+                        .soldier_advice =
+                        match val.into::<i16>("other player soldier advice")? {
+                            ..=-1 => None,
+                            x => Some(x.try_into().unwrap_or(1)),
+                        };
                 }
                 "owngroupdescription" => self
                     .guild
@@ -975,6 +981,7 @@ impl GameState {
                             oop.pet_attribute_bonus_perc;
                         op.wall_combat_lvl = oop.wall_combat_lvl;
                         op.fortress_rank = oop.fortress_rank;
+                        op.soldier_advice = oop.soldier_advice;
                     }
                     other_player = Some(op);
                 }

--- a/src/gamestate/social.rs
+++ b/src/gamestate/social.rs
@@ -410,7 +410,7 @@ pub struct OtherPlayer {
     pub armor: u64,
     pub min_damage_base: u32,
     pub max_damage_base: u32,
-
+    pub soldier_advice: Option<u16>,
     pub fortress: Option<OtherFortress>,
 }
 


### PR DESCRIPTION
Soldier advice is used for the fortress attacks its the games advice of how many soldiers you should use when performing a fortress attack