### PR TITLE
Fix typos in project

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If you use a single sign-on S&F Account, you can use it like this:
 
 The `SimpleSession` is not optimal for more complex usecases. For these, have a
 look at `Session::new()` & `GameState::new()` to handle session and gamestate
-seperately
+separately
 
 ## Installation
 
@@ -75,7 +75,7 @@ Here are a few things you should note before getting your account banned:
 
 ## Performance
 
-Performace should not matter to you, as you are not supposed to run this library on a scale, where you have to think about this. Disregarding this fact, this library is build with high scalabillity and low resource usage in mind. Parsing the login gamestate will take < 1ms on my machine with full updates after that taking < 100µs.
+Performance should not matter to you, as you are not supposed to run this library on a scale, where you have to think about this. Disregarding this fact, this library is build with high scalabillity and low resource usage in mind. Parsing the login gamestate will take < 1ms on my machine with full updates after that taking < 100µs.
 
 Everything is parsed into the exact datatype, that is expected, which also catches weird, or unexpected errors compared to just i64ing every int. A lot of these conversion errors are shown as log warnings and defaulting to some value, instead of returning an error. This way you will not get hard stuck, just because the mushroom price of an item somewhere is negative
 

--- a/examples/expedition.rs
+++ b/examples/expedition.rs
@@ -33,7 +33,7 @@ pub async fn main() {
                     // normally you could just do quests here
                     if !exp.is_event_ongoing() {
                         println!(
-                            "Expeditions are currrently not enabled, so we \
+                            "Expeditions are currently not enabled, so we \
                              can not do anything"
                         );
                         break;

--- a/src/command.rs
+++ b/src/command.rs
@@ -123,7 +123,7 @@ pub enum Command {
     StartQuest {
         /// The position of the quest in the quest array
         quest_pos: usize,
-        /// Has the player acknowledget, that their inventory is full and this
+        /// Has the player acknowledged, that their inventory is full and this
         /// may lead to the loss of an item?
         overwrite_inv: bool,
     },
@@ -158,7 +158,7 @@ pub enum Command {
     /// Increases the given base attribute to the requested number. Should be
     /// `current + 1`
     IncreaseAttribute {
-        /// The atrribute you want to increase
+        /// The attribute you want to increase
         attribute: AttributeType,
         /// The value you increase it to. This should be `current + 1`
         increase_to: u32,
@@ -307,7 +307,7 @@ pub enum Command {
     /// Deletes a single message, if you provide the index. -1 = all
     MessageDelete {
         /// The position of the message to delete in the inbox vec. If this is
-        /// -1, it seletes all
+        /// -1, it deletes all
         pos: i32,
     },
     /// Pulls up your scrapbook to reveal more info, than normal
@@ -394,7 +394,7 @@ pub enum Command {
     },
     /// Sends a message to another player
     SendMessage {
-        /// The name of the player to send a mesage to
+        /// The name of the player to send a message to
         to: String,
         /// The message to send
         msg: String,
@@ -403,8 +403,8 @@ pub enum Command {
     /// server. The problem is, that special chars like '/' have to get
     /// escaped into two chars "$s" before getting send to the server.
     /// That means this string can be 120-240 chars long depending on the
-    /// amount of escaped chars. We 'could' trunctate the response, but
-    /// that could get weird with character boundries in UTF8 and split the
+    /// amount of escaped chars. We 'could' truncate the response, but
+    /// that could get weird with character boundaries in UTF8 and split the
     /// escapes themself, so just make sure you provide a valid value here
     /// to begin with and be prepared for a server error
     SetDescription {
@@ -492,7 +492,7 @@ pub enum Command {
     },
     /// Starts the search for gems
     FortressGemStoneSearch,
-    /// Cancles the search for gems
+    /// Cancels the search for gems
     FortressGemStoneSearchCancel,
     /// Finishes the gem stone search using the appropriate amount of
     /// mushrooms. The price is one mushroom per 600 sec / 10 minutes of time
@@ -520,7 +520,7 @@ pub enum Command {
         player_name: String,
         message: String,
     },
-    /// Collects the ressources of the selected type in the underworld
+    /// Collects the resources of the selected type in the underworld
     UnderworldCollect {
         resource: UnderWorldResourceType,
     },
@@ -569,7 +569,7 @@ pub enum Command {
     },
     /// Sacrifice all the money in the idle game for runes
     IdleSacrifice,
-    /// Upgrades a skill to the requested atribute. Should probably be just
+    /// Upgrades a skill to the requested attribute. Should probably be just
     /// current + 1 to mimic a user clicking
     UpgradeSkill {
         attribute: AttributeType,
@@ -814,7 +814,7 @@ pub enum ShopType {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The "curency" you want to use to skip a quest
+/// The "currency" you want to use to skip a quest
 pub enum TimeSkip {
     Mushroom = 1,
     Glass = 2,

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::{error::Error, fmt::Display};
 #[derive(Debug)]
 #[non_exhaustive]
 #[allow(clippy::module_name_repetitions)]
-/// An error, that occured during the communication (sending/receiving/parsing)
+/// An error, that occurred during the communication (sending/receiving/parsing)
 /// of requests to the S&F server
 pub enum SFError {
     /// Whatever you were trying to send was not possible to send. This is

--- a/src/gamestate/character.rs
+++ b/src/gamestate/character.rs
@@ -28,9 +28,9 @@ pub struct Character {
 
     /// The class of this character
     pub class: Class,
-    /// Iff this character is a druid, this will be the currently equiped mask
+    /// Iff this character is a druid, this will be the currently equipped mask
     pub druid_mask: Option<DruidMask>,
-    /// Iff this character is a bard, this will be the currently equiped
+    /// Iff this character is a bard, this will be the currently equipped
     /// instrument
     pub bard_instrument: Option<BardInstrument>,
 
@@ -64,7 +64,7 @@ pub struct Character {
     /// The potions currently active
     pub active_potions: [Option<Potion>; 3],
 
-    /// The total armor of our character. Basically all equiped armor combined
+    /// The total armor of our character. Basically all equipped armor combined
     pub armor: u64,
 
     /// The min amount of damage the weapon claims it can do without any bonus
@@ -76,7 +76,7 @@ pub struct Character {
     pub attribute_basis: EnumMap<AttributeType, u32>,
     /// All bonus attributes from quipment/pets/potions
     pub attribute_additions: EnumMap<AttributeType, u32>,
-    /// The amount of times an atribute has been bought already.
+    /// The amount of times an attribute has been bought already.
     /// Important to calculate the price of the next attribute to buy
     pub attribute_times_bought: EnumMap<AttributeType, u32>,
 

--- a/src/gamestate/dungeons.rs
+++ b/src/gamestate/dungeons.rs
@@ -52,9 +52,9 @@ impl Portal {
 pub struct Dungeons {
     /// The next time you can fight in the dungeons for free
     pub next_free_fight: Option<DateTime<Local>>,
-    /// All the light dungeons. Noteably tower information is also in here
+    /// All the light dungeons. Notably tower information is also in here
     pub light: EnumMap<LightDungeon, DungeonProgress>,
-    /// All the shadow dungeons. Noteably twister & cont. loop of idols is also
+    /// All the shadow dungeons. Notably twister & cont. loop of idols is also
     /// in here
     pub shadow: EnumMap<ShadowDungeon, DungeonProgress>,
     pub portal: Option<Portal>,

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -128,11 +128,11 @@ pub struct FortressProduction {
     /// The maximum amount of this resource, that this building can store. If
     /// `building_collectable == building_limit` the production stops
     pub limit: u64,
-    /// The amount of this resource the coresponding production building
+    /// The amount of this resource the corresponding production building
     /// produces per hour
     pub per_hour: u64,
     /// The amount of this resource the building produces on the next level per
-    /// hour. If the resouce is Experience, this will be 0
+    /// hour. If the resource is Experience, this will be 0
     pub per_hour_next_lvl: u64,
 }
 
@@ -220,7 +220,7 @@ impl<T> Default for FortressAction<T> {
 #[derive(Debug, Clone, Copy, EnumCount, PartialEq, Eq, Enum, EnumIter)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of a unit useable in the fortress
+/// The type of a unit usable in the fortress
 pub enum FortressUnitType {
     Soldier = 0,
     Magician = 1,

--- a/src/gamestate/guild.rs
+++ b/src/gamestate/guild.rs
@@ -13,7 +13,7 @@ use crate::misc::{from_sf_string, soft_into, warning_parse};
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Informaion about the characters current guild
+/// Information about the characters current guild
 pub struct Guild {
     /// The internal server id of this guild
     pub id: u32,
@@ -56,7 +56,7 @@ pub struct Guild {
     pub pet_id: u32,
     /// The maximum level, that the pet can be at
     pub pet_max_lvl: u16,
-    /// All informations about the hydra the guild pet can fight
+    /// All information about the hydra the guild pet can fight
     pub hydra: GuildHydra,
     /// The thing each player can enter and fight once a day
     pub portal: GuildPortal,
@@ -95,7 +95,7 @@ pub struct GuildHydra {
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The customizeable emblem each guild has
+/// The customizable emblem each guild has
 pub struct Emblem {
     raw: String,
 }

--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -138,7 +138,7 @@ pub struct Equipment(pub EnumMap<EquipmentSlot, Option<Item>>);
 
 impl Equipment {
     #[must_use]
-    /// Checks if the character has an item with the enchantment equiped
+    /// Checks if the character has an item with the enchantment equipped
     pub fn has_enchantment(&self, enchantment: Enchantment) -> bool {
         let item = self.0.get(enchantment.equipment_slot());
         if let Some(item) = item {
@@ -183,7 +183,7 @@ pub struct Item {
     /// or the weapon types damages though, if you want to have a safe
     /// abstraction. This is only public in case I am missing a case here
     pub type_specific_val: u32,
-    /// The stats this item gives, when equiped
+    /// The stats this item gives, when equipped
     pub attributes: EnumMap<AttributeType, u32>,
     /// The gemslot of this item, if any. A gemslot can be filled or empty
     pub gem_slot: Option<GemSlot>,
@@ -415,7 +415,7 @@ pub struct Rune {
     /// The type of tune this is
     pub typ: RuneType,
     /// The "strength" of this rune. So a value like 50 here and a typ of
-    /// `FireResistance` would mean 50% fire resistence
+    /// `FireResistance` would mean 50% fire resistance
     pub value: u8,
 }
 
@@ -561,7 +561,7 @@ impl ItemType {
         )
     }
 
-    /// The equipment slot, that this item type can be equiped to
+    /// The equipment slot, that this item type can be equipped to
     #[must_use]
     pub fn equipment_slot(&self) -> Option<EquipmentSlot> {
         Some(match self {
@@ -779,7 +779,7 @@ impl PotionSize {
 #[derive(Debug, Clone, PartialEq, Eq, Copy, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// Differenciates resource items
+/// Differentiates resource items
 pub enum ResourceType {
     Wood = 17,
     Stone,
@@ -843,7 +843,7 @@ impl GemType {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Enum, EnumIter)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// Denotes the place, where an item is equiped
+/// Denotes the place, where an item is equipped
 pub enum EquipmentSlot {
     Hat = 1,
     BreastPlate,
@@ -880,7 +880,7 @@ impl EquipmentSlot {
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// An item useable for pets
+/// An item usable for pets
 pub enum PetItem {
     Egg(HabitatType),
     SpecialEgg(HabitatType),

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -134,11 +134,11 @@ impl Shop {
 }
 
 impl GameState {
-    /// Constructs a new `GameState` from the provided response. The reponse has
+    /// Constructs a new `GameState` from the provided response. The response has
     /// to be the login response from a `Session`.
     ///
     /// # Errors
-    /// If the reponse contains any errors, or does not contain enough
+    /// If the response contains any errors, or does not contain enough
     /// information about the player to build a full `GameState`, this will
     /// return a `ParsingError`, or `TooShortResponse` depending on the
     /// exact error

--- a/src/gamestate/social.rs
+++ b/src/gamestate/social.rs
@@ -368,7 +368,7 @@ pub struct OtherPlayer {
     pub name: String,
     /// The level of the player
     pub level: u16,
-    /// The description this player has set for themselfes
+    /// The description this player has set for themselves
     pub description: String,
     /// If the player is in a guild, this will contain the name
     pub guild: Option<String>,

--- a/src/gamestate/tavern.rs
+++ b/src/gamestate/tavern.rs
@@ -36,7 +36,7 @@ pub struct Tavern {
     pub toilet: Option<Toilet>,
     /// The dice game you can play with the weird guy in the tavern
     pub dice_game: DiceGame,
-    /// Informations about everything related to expeditions
+    /// Information about everything related to expeditions
     pub expeditions: ExpeditionsEvent,
     /// Decides if you can on on expeditions, or quests, when this event is
     /// currently ongoing
@@ -47,7 +47,7 @@ pub struct Tavern {
 
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Informations about everything related to expeditions
+/// Information about everything related to expeditions
 pub struct ExpeditionsEvent {
     /// The time the expeditions mechanic was enabled at
     pub start: Option<DateTime<Local>>,
@@ -55,7 +55,7 @@ pub struct ExpeditionsEvent {
     pub end: Option<DateTime<Local>>,
     /// The expeditions available to do
     pub available: Vec<AvailableExpedition>,
-    /// The expedition the player is currenty doing. Accessable via the
+    /// The expedition the player is currently doing. Accessible via the
     /// `active()` method.
     pub(crate) active: Option<Expedition>,
 }
@@ -173,7 +173,7 @@ impl Tavern {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// One of the three possible quests in the tavern
 pub struct Quest {
-    /// The legth of this quest in sec (without item enchantment)
+    /// The length of this quest in sec (without item enchantment)
     pub base_length: u32,
     /// The silver reward for this quest (without item enchantment)
     pub base_silver: u32,
@@ -181,9 +181,9 @@ pub struct Quest {
     pub base_experience: u32,
     /// The item reward for this quest
     pub item: Option<Item>,
-    /// The place where this quest takes place. Usefull for the scrapbook
+    /// The place where this quest takes place. Useful for the scrapbook
     pub location_id: Location,
-    /// The enemy you fight in this quest. Usefull for the scrapbook
+    /// The enemy you fight in this quest. Useful for the scrapbook
     pub monster_id: u16,
 }
 
@@ -392,7 +392,7 @@ impl Expedition {
     }
 
     #[must_use]
-    /// Returns the current stage the player is doing. This is dependant on
+    /// Returns the current stage the player is doing. This is dependent on
     /// time, because the timers are lazily evaluated. That means it might
     /// flip from Waiting->Encounters/Finished between calls
     pub fn current_stage(&self) -> ExpeditionStage {
@@ -413,7 +413,7 @@ impl Expedition {
     }
 
     #[must_use]
-    /// Cheks, if the last timer of this expedition has run out
+    /// Checks, if the last timer of this expedition has run out
     pub fn is_finished(&self) -> bool {
         matches!(self.current_stage(), ExpeditionStage::Finished)
     }
@@ -430,7 +430,7 @@ pub enum ExpeditionStage {
     /// The different encounters, that you can choose between. Should be <= 3
     Encounters(Vec<ExpeditionEncounter>),
     /// We have to wait until the specified time to continue in the expedition.
-    /// When this is `< Local::now()`, you can can send teh update command to
+    /// When this is `< Local::now()`, you can can send the update command to
     /// update the expedition stage, which will make `current_stage()` yield
     /// the new encounters
     Waiting(DateTime<Local>),

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -25,7 +25,7 @@ pub struct Underworld {
     pub last_collectable_update: Option<DateTime<Local>>,
 
     // Both XP&silver are not really resources, so I just have this here,
-    // instead of in a resouce info struct like in fortress
+    // instead of in a resource info struct like in fortress
     /// The current souls in the underworld
     pub souls_current: u64,
     /// The maximum amount of souls, that you can store in the underworld.  If
@@ -184,7 +184,7 @@ pub struct UnderworldProduction {
     /// The maximum amount of this resource, that this building can store. If
     /// `building_collectable == building_limit` the production stops
     pub limit: u64,
-    /// The amount of this resource the coresponding production building
+    /// The amount of this resource the corresponding production building
     /// produces per hour. The adventuromatics amount will be per day here
     pub per_hour: u64,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub mod sso;
 /// This is the numerical id of a player on a server. Note that in rare edge
 /// cases this might be 0 (you are the first person to unlock the Dungeon. Who
 /// do you fight?), but you can almost always expect this to be > 0
-/// whereever found
+/// wherever found
 pub type PlayerId = u32;
 
 #[derive(Debug)]
@@ -123,7 +123,7 @@ impl SimpleSession {
     /// - `ParsingError`: If the response from the server was unexpected in some
     ///   way
     /// - `TooShortResponse` Similar to `ParsingError`, but specific to a
-    ///   response being too short, which would normaly trigger a out of bound
+    ///   response being too short, which would normally trigger a out of bound
     ///   panic
     /// - `ServerError`: If the server itself responded with an ingame error
     ///   like "you do not have enough silver to do that"

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -27,7 +27,7 @@ pub(crate) fn sha1_hash(val: &str) -> String {
 }
 
 /// Converts a raw value into the appropriate type. If that is not possible,
-/// a warning will be emmitted and the given default returned. This is useful
+/// a warning will be emitted and the given default returned. This is useful
 /// for stuff, that should not crash everything, when there is a weird value and
 /// the silent failure of `as T`, or `unwrap_or_default()` would yield worse
 /// results and/or no warning

--- a/src/session.rs
+++ b/src/session.rs
@@ -48,7 +48,7 @@ pub struct Session {
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The pasword of a character, hashed in the way, that the server expects
+/// The password of a character, hashed in the way, that the server expects
 pub struct PWHash(String);
 
 impl PWHash {
@@ -59,7 +59,7 @@ impl PWHash {
         Self(sha1_hash(&(password.to_string() + HASH_CONST)))
     }
     /// If you have access to the hash of the password directly, this method
-    /// lets you contruct a `PWHash` directly
+    /// lets you construct a `PWHash` directly
     #[must_use]
     pub fn from_hash(hash: String) -> Self {
         Self(hash)
@@ -139,7 +139,7 @@ impl Session {
 
     /// Checks if this session has ever been able to successfully login to the
     /// server to establish a session id. You should not need to check this, as
-    /// `login()` should return error on unsuccessfull logins, but if you want
+    /// `login()` should return error on unsuccessful logins, but if you want
     /// to make sure, you can make sure here
     #[must_use]
     pub fn has_session_id(&self) -> bool {
@@ -518,7 +518,7 @@ impl<'de> serde::Deserialize<'de> for Response {
                     .ok_or_else(|| serde::de::Error::missing_field("j"))?;
 
                 Response::parse(body, received_at).map_err(|_| {
-                    serde::de::Error::custom("invalid resopnse body")
+                    serde::de::Error::custom("invalid response body")
                 })
             }
         }
@@ -554,15 +554,15 @@ impl Response {
         self.with_received_at(|a| *a)
     }
 
-    /// Parses a response body from the server into a useable format
-    /// You might want to use this, if you are analyzing reponses from the
+    /// Parses a response body from the server into a usable format
+    /// You might want to use this, if you are analyzing responses from the
     /// browsers network tab. If you are trying to store/read responses to/from
     /// disk to cache them, or otherwise, you should use the sso feature to
     /// serialize/deserialize them instead
     ///
     /// # Errors
     /// - `ServerError`: If the server responsed with an error
-    /// - `ParsingError`: If the reponse does not follow the standard S&F server
+    /// - `ParsingError`: If the response does not follow the standard S&F server
     ///   response schema
     pub fn parse(
         og_body: String,
@@ -660,7 +660,7 @@ impl<'a> ResponseVal<'a> {
     /// Converts the response value into the required type
     ///
     /// # Errors
-    /// If the reponse value can not be parsed into the output
+    /// If the response value can not be parsed into the output
     /// value, a `ParsingError` will be returned
     pub fn into<T: FromStr>(self, name: &'static str) -> Result<T, SFError> {
         self.value.trim().parse().map_err(|_| {
@@ -753,7 +753,7 @@ enum LoginData {
 }
 
 #[derive(Debug, Clone)]
-/// Stores all information necessary to talk to the server. Noteably, if you
+/// Stores all information necessary to talk to the server. Notably, if you
 /// clone this, instead of creating this multiple times for characters on a
 /// server, this will use the same `reqwest::Client`, which can have slight
 /// benefits to performance
@@ -837,7 +837,7 @@ pub(crate) fn reqwest_client(
 }
 
 /// This function is designed for reverseengineering encrypted commands from the
-/// S&F web client. It expects a login resonse, which is the ~3KB string
+/// S&F web client. It expects a login response, which is the ~3KB string
 /// response you can see in the network tab of your browser, that starts with
 /// `serverversion` after a login. After that, you can take any url the client
 /// sends to the server and have it decoded into the actual string command, that

--- a/src/sso.rs
+++ b/src/sso.rs
@@ -196,7 +196,7 @@ impl SFAccount {
     }
 
     /// Queries the SSO for all characters associated with this account. This
-    /// consumes the Account, as the character sessions may need to referesh
+    /// consumes the Account, as the character sessions may need to refresh
     /// the accounts session, which they are only allowed to do, if they own it
     /// (in an Arc<Mutex<_>>) and there should be no need to keep the account
     /// around anyways
@@ -252,7 +252,7 @@ impl SFAccount {
     }
 }
 
-/// Send a request to the SSO server. The endoint will be "json/*". We try
+/// Send a request to the SSO server. The endpoint will be "json/*". We try
 /// to check if the response is bad in any way, but S&F responses never obey
 /// to HTML status codes, or their own system, so good luck
 #[allow(clippy::items_after_statements)]


### PR DESCRIPTION
These typos were found by running following command:

```sh
codespell --write-changes --ignore-regex '\bcrate\b'
```

Afterwards I checked the changes that were made and removed some false
positives.

See: https://github.com/codespell-project/codespell