### PR TITLE
Fix druid not dodging & thus not activating bear form (also add assassin dodge chance)

### DIFF
--- a/src/simulate/mod.rs
+++ b/src/simulate/mod.rs
@@ -670,8 +670,10 @@ fn attack(
             };
             logger.log(BE::Dodged(attacker, defender));
         }
-        if defender.class == Class::Scout && rng.bool() {
-            
+        // Scout and assassin have 50% dodge chance
+        if (defender.class == Class::Scout || defender.class == Class::Assassin)
+            && rng.bool()
+        {
             logger.log(BE::Dodged(attacker, defender));
             return;
         }

--- a/src/simulate/mod.rs
+++ b/src/simulate/mod.rs
@@ -660,17 +660,18 @@ fn attack(
     logger.log(BE::Attack(attacker, defender, typ));
     // Check dodges
     if attacker.class != Class::Mage {
-        // TODO: Different dodge rates (druid 35%)
+        // Druid has 35% dodge chance
+        if defender.class == Class::Druid && rng.f32() <= 0.35 {
+            // TODO: is this instant, or does this trigger on start of def.
+            // turn?
+            defender.class_effect = ClassEffect::Druid {
+                bear: true,
+                swoops: defender.class_effect.druid_swoops(),
+            };
+            logger.log(BE::Dodged(attacker, defender));
+        }
         if defender.class == Class::Scout && rng.bool() {
-            // defender dodged
-            if defender.class == Class::Druid {
-                // TODO: is this instant, or does this trigger on start of def.
-                // turn?
-                defender.class_effect = ClassEffect::Druid {
-                    bear: true,
-                    swoops: defender.class_effect.druid_swoops(),
-                };
-            }
+            
             logger.log(BE::Dodged(attacker, defender));
             return;
         }


### PR DESCRIPTION
I think it's easy to verify, that class == Scout && class == Druid can not be true at the same time.


Edit: Assassin was missing entirely, I have added a commit for that aswell.