### PR TITLE
Add function to determine required fortress level

### DIFF
--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -167,6 +167,27 @@ pub enum FortressBuildingType {
     Wall = 11,
 }
 
+impl FortressBuildingType {
+    /// Minimal fortress level which is required to be allowed to build this
+    /// building
+    pub fn required_min_fortress_level(&self) -> u16 {
+        match self {
+            FortressBuildingType::Fortress => 0,
+            FortressBuildingType::LaborersQuarters => 1,
+            FortressBuildingType::WoodcuttersHut => 1,
+            FortressBuildingType::Quarry => 1,
+            FortressBuildingType::GemMine => 3,
+            FortressBuildingType::Academy => 6,
+            FortressBuildingType::ArcheryGuild => 5,
+            FortressBuildingType::Barracks => 4,
+            FortressBuildingType::MagesTower => 7,
+            FortressBuildingType::Treasury => 2,
+            FortressBuildingType::Smithy => 1,
+            FortressBuildingType::Wall => 4,
+        }
+    }
+}
+
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Information about a single type of unit


### PR DESCRIPTION
Depending on the building type, a specific fortress level is required to be allowed to build it. The new helper function returns such fortress level.