### PR TITLE
Fix item parsing of raw type 12

### DIFF
--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -733,27 +733,32 @@ impl ItemType {
                     piece => ItemType::Shard { piece },
                 }
             }
-            12 if sub_ident > 16 => {
-                let Some(typ) = FromPrimitive::from_i64(sub_ident) else {
-                    return unknown_item("resource type");
-                };
-                ItemType::Resource {
-                    amount: data.csiget(7, "resource amount", 0)?,
-                    typ,
-                }
-            }
             12 => {
-                let Some(typ) = PotionType::parse(sub_ident) else {
-                    return unknown_item("potion type");
-                };
-                let Some(size) = PotionSize::parse(sub_ident) else {
-                    return unknown_item("potion size");
-                };
-                ItemType::Potion(Potion {
-                    typ,
-                    size,
-                    expires: data.cstget(4, "potion expires", server_time)?,
-                })
+                if sub_ident > 16 {
+                    let Some(typ) = FromPrimitive::from_i64(sub_ident) else {
+                        return unknown_item("resource type");
+                    };
+                    ItemType::Resource {
+                        amount: data.csiget(7, "resource amount", 0)?,
+                        typ,
+                    }
+                } else {
+                    let Some(typ) = PotionType::parse(sub_ident) else {
+                        return unknown_item("potion type");
+                    };
+                    let Some(size) = PotionSize::parse(sub_ident) else {
+                        return unknown_item("potion size");
+                    };
+                    ItemType::Potion(Potion {
+                        typ,
+                        size,
+                        expires: data.cstget(
+                            4,
+                            "potion expires",
+                            server_time,
+                        )?,
+                    })
+                }
             }
             13 => ItemType::Scrapbook,
             15 => {

--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -734,8 +734,10 @@ impl ItemType {
                 }
             }
             12 => {
-                if sub_ident > 16 {
-                    let Some(typ) = FromPrimitive::from_i64(sub_ident) else {
+                let id = sub_ident & 0xFF;
+
+                if id > 16 {
+                    let Some(typ) = FromPrimitive::from_i64(id) else {
                         return unknown_item("resource type");
                     };
                     ItemType::Resource {
@@ -743,10 +745,10 @@ impl ItemType {
                         typ,
                     }
                 } else {
-                    let Some(typ) = PotionType::parse(sub_ident) else {
+                    let Some(typ) = PotionType::parse(id) else {
                         return unknown_item("potion type");
                     };
-                    let Some(size) = PotionSize::parse(sub_ident) else {
+                    let Some(size) = PotionSize::parse(id) else {
                         return unknown_item("potion size");
                     };
                     ItemType::Potion(Potion {


### PR DESCRIPTION
I had the problem that an eternal life potion could not be parsed correctly. The reason for this was that `sub_ident` had the value 655360016. Since the value was greater than 16, it was incorrectly assumed that this is a resource. However, it could not be parsed as a resource either, since in this case the value can only be between 17 and 21. As a result, this particular eternal life potion was parsed as `ItemType::Unknown`.

This only happened with one eternal life potion, other ones were working fine. It is possible that this item is very old because this character exists for many years and I only recently started using it again. But I'm not sure when exactly this potion was bought.