### PR TITLE
Implement trait `PartialEq` for `Command`

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 #[non_exhaustive]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A command, that can be send to the sf server
 pub enum Command {
@@ -735,7 +735,7 @@ pub enum ExpeditionSetting {
     PreferQuests,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum BlacksmithAction {
     Dismantle = 201,
@@ -746,7 +746,7 @@ pub enum BlacksmithAction {
     Upgrade = 204,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum FortunePayment {
     LuckyCoins = 0,
@@ -754,7 +754,7 @@ pub enum FortunePayment {
     FreeTurn,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The price you have to pay to roll the dice
 pub enum RollDicePrice {

--- a/src/gamestate/guild.rs
+++ b/src/gamestate/guild.rs
@@ -93,7 +93,7 @@ pub struct GuildHydra {
     pub attributes: EnumMap<AttributeType, u32>,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The customizable emblem each guild has
 pub struct Emblem {
@@ -420,7 +420,7 @@ pub enum GuildRank {
     Invited = 4,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Something the player can upgrade in the guild
 #[allow(missing_docs)]

--- a/src/gamestate/social.rs
+++ b/src/gamestate/social.rs
@@ -435,7 +435,7 @@ pub struct OtherFortress {
     pub fortress_archers_lvl: u16,
 }
 
-#[derive(Debug, Default, Clone, FromPrimitive, Copy)]
+#[derive(Debug, Default, Clone, FromPrimitive, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Relationship {
     #[default]

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -160,7 +160,7 @@ impl Underworld {
     }
 }
 
-#[derive(Debug, Clone, Copy, strum::EnumCount, Enum)]
+#[derive(Debug, Clone, Copy, strum::EnumCount, Enum, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 /// The type of a produceable resource in the underworld
@@ -190,7 +190,14 @@ pub struct UnderworldProduction {
 }
 
 #[derive(
-    Debug, Clone, Copy, FromPrimitive, strum::EnumCount, Enum, EnumIter,
+    Debug,
+    Clone,
+    Copy,
+    FromPrimitive,
+    strum::EnumCount,
+    Enum,
+    EnumIter,
+    PartialEq,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
@@ -208,7 +215,7 @@ pub enum UnderworldBuildingType {
     Keeper = 9,
 }
 
-#[derive(Debug, Clone, Copy, strum::EnumCount, Enum, EnumIter)]
+#[derive(Debug, Clone, Copy, strum::EnumCount, Enum, EnumIter, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 /// The type of unit in the underworld


### PR DESCRIPTION
To do so it was necessary to implement this trait for the enums and structs `Command` depends on as well.

This has been done to more effectively check for equality in unit tests. The macro `matches!()` for example is not able to check if the fields of the enum match as well.

Now the following is possible:

```rust
let command = Command::FortressBuild {
    f_type: FortressBuildingType::Academy,
};
let building_type = FortressBuildingType::Academy;

assert_eq!(
    command,
    Command::FortressBuild {
        f_type: building_type
    }
);
```