### PR TITLE
Add function to check if a `DateTime` is in the future

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1748,6 +1748,13 @@ impl ServerTime {
         Local::now().naive_local() + Duration::seconds(self.0)
     }
 
+    /// Checks whether or not `datetime` is in the future compared to the server
+    /// time
+    #[must_use]
+    pub fn is_in_future(&self, datetime: &DateTime<Local>) -> bool {
+        datetime.naive_local() > self.current()
+    }
+
     #[must_use]
     pub fn next_midnight(&self) -> std::time::Duration {
         let current = self.current();


### PR DESCRIPTION
The are a fair number of `DateTime`s in this API where one wants to know if they are in the future or the past. This new function can be used to determine this. To check if the given `datetime` is in the present or the past, just negate the result.