### PR TITLE
Added Fortress.in_use() and Building->Unit mapping, improved Fortress.can_build()

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -479,6 +479,10 @@ pub enum Command {
         /// The building you want to cancel the upgrade, or build of
         f_type: FortressBuildingType,
     },
+    /// Finish building/upgrading a Building
+    /// When mushrooms != 0, mushrooms will be used to "skip" the upgrade timer.
+    /// However, this command also needs to be sent when not skipping the wait,
+    /// with mushrooms = 0, after the build/upgrade timer has finished.
     FortressBuildFinish {
         f_type: FortressBuildingType,
         mushrooms: u32,

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -277,6 +277,33 @@ impl Fortress {
             FortressBuildingType::MagesTower,
             FortressBuildingType::Wall,
         ];
+
+        // Check if units are being trained in the building (soldiers in barracks, magicians in mages' tower, archers in archery guild)
+        match building_type {
+            FortressBuildingType::Barracks => {
+                if let Some(finish) = self.units.get(FortressUnitType::Soldier).training.finish {
+                    if finish > Local::now() {
+                        return false;
+                    }
+                }
+            },
+            FortressBuildingType::MagesTower => {
+                if let Some(finish) = self.units.get(FortressUnitType::Magician).training.finish {
+                    if finish > Local::now() {
+                        return false;
+                    }
+                }
+            },
+            FortressBuildingType::ArcheryGuild => {
+                if let Some(finish) = self.units.get(FortressUnitType::Archer).training.finish {
+                    if finish > Local::now() {
+                        return false;
+                    }
+                }
+            },
+            _ => {}
+        };
+        
         // Smithy can only be built if these buildings exist
         let can_smithy_be_built = smithy_required_buildings
             .map(|required_building| {

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -278,7 +278,7 @@ impl Fortress {
             FortressBuildingType::Wall,
         ];
 
-        // Check if units are being trained in the building (soldiers in barracks, magicians in mages' tower, archers in archery guild)
+        // Check if units are being trained in the building (soldiers in barracks, magicians in mages' tower, archers in archery guild), or gem mining is in progress
         match building_type {
             FortressBuildingType::Barracks => {
                 if let Some(finish) = self.units.get(FortressUnitType::Soldier).training.finish {
@@ -296,6 +296,13 @@ impl Fortress {
             },
             FortressBuildingType::ArcheryGuild => {
                 if let Some(finish) = self.units.get(FortressUnitType::Archer).training.finish {
+                    if finish > Local::now() {
+                        return false;
+                    }
+                }
+            },
+            FortressBuildingType::GemMine => {
+                if let Some(finish) = self.gem_search.finish {
                     if finish > Local::now() {
                         return false;
                     }


### PR DESCRIPTION
- Added a check in can_build() for character level >= 25 to be able to build/upgrade
- Added Fortress.in_use() which checks if a building is doing something preventing its upgrade
- Changed can_build() to check in_use() when determining whether building can be upgraded.

The character level check requires an extra argument for can_build(), which breaks compatibility. Is that an issue, or are there any workaround suggestions to preserve compatibility?