### PR TITLE
Add command and parsing for fortress secret storage

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -468,6 +468,15 @@ pub enum Command {
         /// The type of resource you want to collect
         resource: FortressResourceType,
     },
+    /// Collects resources from the fortress secret storage
+    /// Note that the official client only ever collect either stone or wood
+    /// but not both at the same time
+    FortressGatherSecretStorage {
+        /// The amount of stone you want to collect
+        stone: u64,
+        /// The amount of wood you want to collect
+        wood: u64,
+    },
     /// Builds, or upgrades a building in the fortress
     FortressBuild {
         /// The building you want to upgrade, or build
@@ -1131,6 +1140,9 @@ impl Command {
             }
             Command::FortressGather { resource } => {
                 format!("FortressGather:{}", *resource as usize + 1)
+            }
+            Command::FortressGatherSecretStorage { stone, wood } => {
+                format!("FortressGatherTreasure:{wood}/{stone}")
             }
             Command::EquipCompanion {
                 from_inventory,

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -72,6 +72,11 @@ pub struct Fortress {
     pub attack_free_reroll: Option<DateTime<Local>>,
     /// The price in silver re-rolling costs
     pub opponent_reroll_price: u64,
+
+    /// The amount of stone currently in your secret storage
+    pub secret_storage_stone: u64,
+    /// The amount of wood currently in your secret storage
+    pub secret_storage_wood: u64,
 }
 
 #[derive(Debug, Default, Clone, Copy)]
@@ -456,6 +461,13 @@ impl Fortress {
         self.attack_target = data.cwiget(587, "fortress enemy")?;
         self.attack_free_reroll =
             data.cstget(586, "fortress attack reroll", server_time)?;
+
+        // Secret storage
+        self.secret_storage_wood =
+            data.csiget(698, "secret storage wood", 0)?;
+        self.secret_storage_stone =
+            data.csiget(700, "secret storage stone", 0)?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Yes the gather command looks a bit crazy, because it is. But I've double and triple checked it and it is actually correct.

Not sure how to feel about you technically being able to send a command like this
```rust
Command::FortressGatherSecretStorage { resource: FortressResourceType::Experience, amount: x }
```
which is wrong and won't work because there is no secret storage for experience only stone and wood.

But I think it's cleaner to use the enum values for stone and wood instead of using something like

```rust
Command::FortressGatherSecretStorage { collect_wood: true,  amount: x } // Collects wood
Command::FortressGatherSecretStorage { collect_wood: false, amount: x } // Collects stone
```

or an entirely new enum.