### PR TITLE
Fix witch sometimes being set before actually being unlocked

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1461,6 +1461,12 @@ impl GameState {
                 self.underworld = None;
             }
         }
+
+        // Witch is automatically unlocked with level 66
+        if self.witch.is_some() && self.character.level < 66 {
+            self.witch = None;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
The witch is automatically unlocked with level 66. No idea why some of my accounts got the witch data send before that but similar to how we handle other unlockables this simply set's it to `None` if we are below level 66.