### PR TITLE
Add simple CI workflows to check formatting and clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,10 +15,34 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build no defaults
       run: cargo build --verbose --no-default-features
     - name: Build
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  format:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: rustfmt
+        toolchain: nightly
+    - uses: actions-rust-lang/rustfmt@v1
+
+  clippy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions-rust-lang/setup-rust-toolchain@v1
+      with:
+        components: clippy
+    - name: Clippy
+      run: cargo clippy --verbose -- -D warnings

--- a/examples/expedition.rs
+++ b/examples/expedition.rs
@@ -33,8 +33,8 @@ pub async fn main() {
                     // normally you could just do quests here
                     if !exp.is_event_ongoing() {
                         println!(
-                            "Expeditions are currently not enabled, so we \
-                             can not do anything"
+                            "Expeditions are currently not enabled, so we can \
+                             not do anything"
                         );
                         break;
                     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -480,9 +480,10 @@ pub enum Command {
         f_type: FortressBuildingType,
     },
     /// Finish building/upgrading a Building
-    /// When mushrooms != 0, mushrooms will be used to "skip" the upgrade timer.
-    /// However, this command also needs to be sent when not skipping the wait,
-    /// with mushrooms = 0, after the build/upgrade timer has finished.
+    /// When mushrooms != 0, mushrooms will be used to "skip" the upgrade
+    /// timer. However, this command also needs to be sent when not
+    /// skipping the wait, with mushrooms = 0, after the build/upgrade
+    /// timer has finished.
     FortressBuildFinish {
         f_type: FortressBuildingType,
         mushrooms: u32,

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,7 +44,7 @@ impl Error for SFError {
         None
     }
 
-    fn description(&self) -> &str {
+    fn description(&self) -> &'static str {
         "description() is deprecated; use Display"
     }
 

--- a/src/gamestate/character.rs
+++ b/src/gamestate/character.rs
@@ -215,10 +215,7 @@ impl Class {
 
     #[must_use]
     pub fn can_wear_shield(self) -> bool {
-        match self {
-            Self::Paladin | Self::Warrior => true,
-            _ => false,
-        }
+        matches!(self, Self::Paladin | Self::Warrior)
     }
 
     #[must_use]

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -192,8 +192,12 @@ impl FortressBuildingType {
     pub fn unit_produced(self) -> Option<FortressUnitType> {
         match self {
             FortressBuildingType::Barracks => Some(FortressUnitType::Soldier),
-            FortressBuildingType::MagesTower => Some(FortressUnitType::Magician),
-            FortressBuildingType::ArcheryGuild => Some(FortressUnitType::Archer),
+            FortressBuildingType::MagesTower => {
+                Some(FortressUnitType::Magician)
+            }
+            FortressBuildingType::ArcheryGuild => {
+                Some(FortressUnitType::Archer)
+            }
             _ => None,
         }
     }
@@ -272,7 +276,9 @@ pub struct FortressBuilding {
 }
 
 impl Fortress {
-    /// Check if units are being trained in the building (soldiers in barracks, magicians in mages' tower, archers in archery guild), or gem mining is in progress
+    /// Check if units are being trained in the building (soldiers in barracks,
+    /// magicians in mages' tower, archers in archery guild), or gem mining is
+    /// in progress
     #[must_use]
     pub fn in_use(&self, building_type: FortressBuildingType) -> bool {
         // Check if associated units are training
@@ -300,7 +306,7 @@ impl Fortress {
     pub fn can_build(
         &self,
         building_type: FortressBuildingType,
-        available_silver: u64
+        available_silver: u64,
     ) -> bool {
         let building_info = self.buildings.get(building_type);
         let fortress_level =
@@ -312,11 +318,13 @@ impl Fortress {
             FortressBuildingType::Wall,
         ];
 
-        // Checks whether a building is in use, in such a way that it prevents upgrading (for example, if a unit is being trained, or gem mining is in progress)
+        // Checks whether a building is in use, in such a way that it prevents
+        // upgrading (for example, if a unit is being trained, or gem mining is
+        // in progress)
         if self.in_use(building_type) {
             return false;
         }
-        
+
         // Smithy can only be built if these buildings exist
         let can_smithy_be_built = smithy_required_buildings
             .map(|required_building| {

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -24,7 +24,8 @@ use crate::{
     error::*,
     gamestate::{
         arena::*, character::*, dungeons::*, fortress::*, guild::*, idle::*,
-        items::*, rewards::*, social::*, tavern::*, unlockables::*,underworld::*,
+        items::*, rewards::*, social::*, tavern::*, underworld::*,
+        unlockables::*,
     },
     misc::*,
     response::Response,

--- a/src/gamestate/tavern.rs
+++ b/src/gamestate/tavern.rs
@@ -258,8 +258,8 @@ pub enum CurrentAction {
         /// The time at which the guard job will be over
         busy_until: DateTime<Local>,
     },
-    /// The character is doing a quest right now. If `busy_until < Local::now()`
-    /// you can send a `FinishQuest` command
+    /// The character is doing a quest right now. If `busy_until <
+    /// Local::now()` you can send a `FinishQuest` command
     Quest {
         /// 0-2 index into tavern quest array
         quest_idx: u8,
@@ -430,9 +430,9 @@ pub enum ExpeditionStage {
     /// The different encounters, that you can choose between. Should be <= 3
     Encounters(Vec<ExpeditionEncounter>),
     /// We have to wait until the specified time to continue in the expedition.
-    /// When this is `< Local::now()`, you can send the update command to update
-    /// the expedition stage, which will make `current_stage()` yield the new
-    /// encounters
+    /// When this is `< Local::now()`, you can send the update command to
+    /// update the expedition stage, which will make `current_stage()`
+    /// yield the new encounters
     Waiting(DateTime<Local>),
     /// The expedition has finished and you can choose another one
     Finished,

--- a/src/misc.rs
+++ b/src/misc.rs
@@ -141,8 +141,8 @@ fn pattern_replace<const FROM: bool>(str: &str) -> String {
     }
 }
 
-/// This function is designed for reverse engineering encrypted commands from the
-/// S&F web client. It expects a login response, which is the ~3KB string
+/// This function is designed for reverse engineering encrypted commands from
+/// the S&F web client. It expects a login response, which is the ~3KB string
 /// response you can see in the network tab of your browser, that starts with
 /// `serverversion` after a login. After that, you can take any URL the client
 /// sends to the server and have it decoded into the actual string command, that

--- a/src/response.rs
+++ b/src/response.rs
@@ -150,8 +150,8 @@ impl Response {
     ///
     /// # Errors
     /// - `ServerError`: If the server responsed with an error
-    /// - `ParsingError`: If the response does not follow the standard S&F server
-    ///   response schema
+    /// - `ParsingError`: If the response does not follow the standard S&F
+    ///   server response schema
     pub fn parse(
         og_body: String,
         received_at: NaiveDateTime,

--- a/src/response.rs
+++ b/src/response.rs
@@ -245,7 +245,7 @@ pub struct ResponseVal<'a> {
     sub_key: &'a str,
 }
 
-impl<'a> ResponseVal<'a> {
+impl ResponseVal<'_> {
     /// Converts the response value into the required type
     ///
     /// # Errors
@@ -306,7 +306,7 @@ impl<'a> ResponseVal<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for ResponseVal<'a> {
+impl std::fmt::Display for ResponseVal<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.value)
     }


### PR DESCRIPTION
Also fixed all the formatting problems and clippy warnings that were already there. This should prevent any new problems from getting into the code base