### PR TITLE
Parse enchantments into idents, that can be used to enchant items.

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -14,7 +14,9 @@ use crate::{
         items::*,
         social::Relationship,
         underworld::*,
-        unlockables::{HabitatType, HellevatorTreatType, Unlockable},
+        unlockables::{
+            EnchantmentIdent, HabitatType, HellevatorTreatType, Unlockable,
+        },
     },
     PlayerId,
 };
@@ -436,7 +438,7 @@ pub enum Command {
     /// with the enchantment
     WitchEnchant {
         /// The enchantment to apply
-        enchantment: Enchantment,
+        enchantment: EnchantmentIdent,
     },
     /// Spins the wheel. All information about when you can spin, or what you
     /// won are in `game_state.specials.wheel`
@@ -1137,7 +1139,7 @@ impl Command {
                 *action as usize
             ),
             Command::WitchEnchant { enchantment } => {
-                format!("PlayerWitchEnchantItem:{}/1", enchantment.enchant_id())
+                format!("PlayerWitchEnchantItem:{}/1", enchantment.0)
             }
             Command::SpinWheelOfFortune {
                 payment: fortune_payment,

--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -480,11 +480,6 @@ impl Enchantment {
             Enchantment::RobberBaronRitual => EquipmentSlot::Talisman,
         }
     }
-
-    #[must_use]
-    pub fn enchant_id(self) -> u32 {
-        ((self as u32) / 10) * 10
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -1,4 +1,4 @@
-use std::num::{NonZero, NonZeroU8};
+use std::num::NonZeroU8;
 
 use chrono::{DateTime, Local};
 use enum_map::Enum;


### PR DESCRIPTION
This is a breaking changes, but the previous method just did not work, so it should be good

TODO: I just tested this for one char and two items, but I need to make sure this is actually the correct approach for all characters

fixes #145 