### PR TITLE
Fix check if gem mine is in use

### DIFF
--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -296,12 +296,10 @@ impl Fortress {
         }
 
         // Check if gem mining is in progress
-        if building_type == FortressBuildingType::GemMine {
-            if let Some(finish) = self.gem_search.finish {
-                if finish > Local::now() {
-                    return true;
-                }
-            }
+        if building_type == FortressBuildingType::GemMine
+            && self.gem_search.finish.is_some()
+        {
+            return true;
         }
         false
     }


### PR DESCRIPTION
To finish the search in the gem mine, the found gem has to be collected using `Command::FortressGemStoneSearchFinish`. This means, as long as this command is not sent, the gem mine is still in use.