### PR TITLE
Fix typos in structs or enums

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -538,7 +538,7 @@ pub enum Command {
     },
     /// Collects the resources of the selected type in the underworld
     UnderworldCollect {
-        resource: UnderWorldResourceType,
+        resource: UnderworldResourceType,
     },
     /// Upgrades the selected underworld unit by one level
     UnderworldUnitUpgrade {

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1320,7 +1320,7 @@ impl GameState {
                     self.hellevator
                         .active
                         .get_or_insert_with(Default::default)
-                        .rewards_nest = HellevatorDailyReward::parse(
+                        .rewards_next = HellevatorDailyReward::parse(
                         &val.into_list("hdrnd").unwrap_or_default(),
                     );
                 }

--- a/src/gamestate/tavern.rs
+++ b/src/gamestate/tavern.rs
@@ -271,7 +271,7 @@ pub enum CurrentAction {
     Expedition,
     /// The character is not able to do something, but we do not know what.
     /// Most likely something from a new update
-    Unkown(Option<DateTime<Local>>),
+    Unknown(Option<DateTime<Local>>),
 }
 
 impl CurrentAction {
@@ -293,7 +293,7 @@ impl CurrentAction {
             (4, None) => CurrentAction::Expedition,
             _ => {
                 error!("Unknown action id combination: {id}, {busy:?}");
-                CurrentAction::Unkown(busy)
+                CurrentAction::Unknown(busy)
             }
         }
     }

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -18,7 +18,7 @@ pub struct Underworld {
     /// Information about all the buildable units in the underworld
     pub units: EnumMap<UnderworldUnitType, UnderworldUnit>,
     /// All information about the production of resources in the underworld
-    pub production: EnumMap<UnderWorldResourceType, UnderworldProduction>,
+    pub production: EnumMap<UnderworldResourceType, UnderworldProduction>,
     /// The `last_collectable` value in `UnderworldProduction` is always out of
     /// date. Refer to the `Fortress.last_collectable_updated` for more
     /// information
@@ -123,7 +123,7 @@ impl Underworld {
 
         #[allow(clippy::enum_glob_use)]
         {
-            use UnderWorldResourceType::*;
+            use UnderworldResourceType::*;
             self.production.get_mut(Souls).last_collectable =
                 data.csiget(459, "uu souls in building", 0)?;
             self.production.get_mut(Souls).limit =
@@ -164,7 +164,7 @@ impl Underworld {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
 /// The type of a producible resource in the underworld
-pub enum UnderWorldResourceType {
+pub enum UnderworldResourceType {
     Souls = 0,
     Silver = 1,
     #[doc(alias = "ALU")]

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -19,7 +19,7 @@ pub struct Underworld {
     pub units: EnumMap<UnderworldUnitType, UnderworldUnit>,
     /// All information about the production of resources in the underworld
     pub production: EnumMap<UnderWorldResourceType, UnderworldProduction>,
-    /// The `last_collectable` value in `UnderWorldResource` is always out of
+    /// The `last_collectable` value in `UnderworldProduction` is always out of
     /// date. Refer to the `Fortress.last_collectable_updated` for more
     /// information
     pub last_collectable_update: Option<DateTime<Local>>,

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -103,7 +103,7 @@ pub struct Hellevator {
     pub start_contrib_date: Option<DateTime<Local>>,
 
     pub rewards_today: Option<HellevatorDailyReward>,
-    pub rewards_nest: Option<HellevatorDailyReward>,
+    pub rewards_next: Option<HellevatorDailyReward>,
 
     pub daily_treat_bonus: Option<HellevatorTreatBonus>,
 

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -187,7 +187,7 @@ pub enum HellevatorMonsterRewardTyp {
     Wood = 6,
     Stone = 7,
     #[default]
-    Unkown = 99,
+    Unknown = 99,
 }
 
 #[derive(Debug, Default, Clone)]


### PR DESCRIPTION
This pull request fixes typos in several structs and enums.

Note that these are breaking changes, but I think, thanks to the Rust compiler, it should be easy to resolve them.