### PR TITLE
Add support for yesterday's daily rewards of Hellevator

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -722,6 +722,7 @@ pub enum Command {
         plain: usize,
     },
     HellevatorClaimDaily,
+    HellevatorClaimDailyYesterday,
     HellevatorClaimFinal,
     HellevatorPreviewRewards,
     HallOfFameHellevatorPage {
@@ -1441,6 +1442,9 @@ impl Command {
             ),
             Command::HellevatorClaimDaily => {
                 format!("GroupTournamentClaimDaily:")
+            }
+            Command::HellevatorClaimDailyYesterday => {
+                format!("GroupTournamentClaimDailyYesterday:")
             }
             Command::HellevatorPreviewRewards => {
                 format!("GroupTournamentPreview:")

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1325,12 +1325,12 @@ impl GameState {
                     );
                 }
                 "gtdailyrewardyesterday" => {
-                    // self.hellevator
-                    //     .active
-                    //     .get_or_insert_with(Default::default)
-                    //     .rewards_yesterday = HellevatorDailyReward::parse(
-                    //     &val.into_list("hdryd").unwrap_or_default(),
-                    // );
+                    self.hellevator
+                        .active
+                        .get_or_insert_with(Default::default)
+                        .rewards_yesterday = HellevatorDailyReward::parse(
+                        &val.into_list("hdryd").unwrap_or_default(),
+                    );
                 }
                 "gtranking" => {
                     self.hall_of_fames.hellevator = val

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1332,6 +1332,39 @@ impl GameState {
                         &val.into_list("hdryd").unwrap_or_default(),
                     );
                 }
+                "gtdailyrewardclaimed" => {
+                    if let Some(hellevator) = self.hellevator.active.as_mut() {
+                        let rewards_yesterday =
+                            hellevator.rewards_yesterday.clone();
+                        let rewards_claimed = HellevatorDailyReward::parse(
+                            &val.into_list("hdrc").unwrap_or_default(),
+                        );
+
+                        if let (
+                            Some(rewards_yesterday),
+                            Some(rewards_claimed),
+                        ) = (rewards_yesterday, rewards_claimed)
+                        {
+                            // This response is sent when either yesterday's
+                            // or today's daily reward was claimed. The
+                            // response value is the claimed reward. By
+                            // comparing it, we can determine which kind of
+                            // reward was claimed.
+                            if rewards_yesterday == rewards_claimed {
+                                // The game doesn't update this value itself, so
+                                // we do it manually.
+                                //
+                                // NOTE: In practice this should be good enough,
+                                // but theoretically it is possible that both
+                                // kind of rewards have the same value. In this
+                                // case, it could happen that yesterday's daily
+                                // reward is reset even though today's daily
+                                // reward was claimed.
+                                hellevator.rewards_yesterday = None;
+                            }
+                        }
+                    }
+                }
                 "gtranking" => {
                     self.hall_of_fames.hellevator = val
                         .as_str()

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -235,7 +235,7 @@ pub struct HellevatorShopTreat {
     pub effect_strength: u32,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HellevatorDailyReward {
     // TODO: What is the purpose of these fields?

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -102,6 +102,7 @@ pub struct Hellevator {
     pub next_reset: Option<DateTime<Local>>,
     pub start_contrib_date: Option<DateTime<Local>>,
 
+    pub rewards_yesterday: Option<HellevatorDailyReward>,
     pub rewards_today: Option<HellevatorDailyReward>,
     pub rewards_nest: Option<HellevatorDailyReward>,
 
@@ -259,7 +260,7 @@ impl HellevatorDailyReward {
     }
 
     pub(crate) fn parse(data: &[i64]) -> Option<HellevatorDailyReward> {
-        if data.len() != 10 {
+        if data.len() < 10 {
             return None;
         }
 

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -238,6 +238,10 @@ pub struct HellevatorShopTreat {
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HellevatorDailyReward {
+    // TODO: What is the purpose of these fields?
+    pub(crate) start_level: u16,
+    pub(crate) end_level: u16,
+
     pub gold_chests: u16,
     pub silver: u64,
 
@@ -265,6 +269,8 @@ impl HellevatorDailyReward {
         }
 
         Some(HellevatorDailyReward {
+            start_level: data.csiget(0, "start level", 0).unwrap_or(0),
+            end_level: data.csiget(1, "end level", 0).unwrap_or(0),
             gold_chests: data.csiget(2, "gold chests", 0).unwrap_or(0),
             silver: data.csiget(5, "silver reward", 0).unwrap_or(0),
             fortress_chests: data.csiget(3, "ft chests", 0).unwrap_or(0),


### PR DESCRIPTION
This pull request adds support for accessing and claiming yesterday's daily rewards of the Hellevator.

As a far as I can tell,  the S&F server only returns yesterday's daily rewards during login. This is unfortunate because it requires that the game state is updated manually.

Some of the logic was already implemented but commented out. I am unsure why this was done, as it seems to work fine.