### PR TITLE
Fix edge case of yesterday's daily reward of Hellevator

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1334,34 +1334,15 @@ impl GameState {
                 }
                 "gtdailyrewardclaimed" => {
                     if let Some(hellevator) = self.hellevator.active.as_mut() {
-                        let rewards_yesterday =
-                            hellevator.rewards_yesterday.clone();
-                        let rewards_claimed = HellevatorDailyReward::parse(
-                            &val.into_list("hdrc").unwrap_or_default(),
-                        );
-
-                        if let (
-                            Some(rewards_yesterday),
-                            Some(rewards_claimed),
-                        ) = (rewards_yesterday, rewards_claimed)
-                        {
-                            // This response is sent when either yesterday's
-                            // or today's daily reward was claimed. The
-                            // response value is the claimed reward. By
-                            // comparing it, we can determine which kind of
-                            // reward was claimed.
-                            if rewards_yesterday == rewards_claimed {
-                                // The game doesn't update this value itself, so
-                                // we do it manually.
-                                //
-                                // NOTE: In practice this should be good enough,
-                                // but theoretically it is possible that both
-                                // kind of rewards have the same value. In this
-                                // case, it could happen that yesterday's daily
-                                // reward is reset even though today's daily
-                                // reward was claimed.
-                                hellevator.rewards_yesterday = None;
-                            }
+                        // This response key is sent when either yesterday's or
+                        // today's daily reward was claimed. To check whether
+                        // yesterday's daily reward was claimed, we check if
+                        // "gtdailyreward" is missing in the response, since it
+                        // is only included if today's daily reward was claimed.
+                        if !new_vals.contains_key("gtdailyreward") {
+                            // The game doesn't update this value itself, so we
+                            // do it manually.
+                            hellevator.rewards_yesterday = None;
                         }
                     }
                 }


### PR DESCRIPTION
This is a follow up of pull request https://github.com/the-marenga/sf-api/pull/153. It introduces a new technique to determine if yesterday's daily reward was claimed. I've tested it with multiple characters and it seems to be reliable.