### PR TITLE
Swap Underworld Resources Souls & Silver

### DIFF
--- a/examples/dungeons.rs
+++ b/examples/dungeons.rs
@@ -54,7 +54,7 @@ pub async fn main() {
             };
             // You should make a better heuristic to find these, but for now we
             // just find the lowest level
-            if best.map_or(true, |old| old.1.level > current.level) {
+            if best.is_none_or(|old| old.1.level > current.level) {
                 best = Some((l.into(), current))
             }
         }

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -165,8 +165,8 @@ impl Underworld {
 #[allow(missing_docs)]
 /// The type of a producible resource in the underworld
 pub enum UnderWorldResourceType {
-    Souls = 0,
-    Silver = 1,
+    Silver = 0,
+    Souls = 1,
     #[doc(alias = "ALU")]
     ThirstForAdventure = 2,
 }


### PR DESCRIPTION
The underworld resources souls & silver have been swapped originally. This has lead to underworld resources not being able to be collected properly (#165). The original issue mentioned upgrading the gold pit below lvl 25 having an influence, but tesing that with an upgrade from 14=>15, the original browser collect requests do not chance, the original order has just been wrong. Looking at all paths where the underworld resources have been used, no other places used the numeric values of the enum, or the order, so this should not break anything, except users, that manually cast them, which I do not really see happening

closes #165 