### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ aho-corasick = "1.1"
 base64 = "0.22"
 chrono = "0.4"
 enum-map = "2.7"
-fastrand = "2.2"
+fastrand = "2.3"
 libaes = "0.7"
 log = "0.4"
 num-bigint = "0.4"
@@ -25,7 +25,7 @@ serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1.0", optional = true }
 sha1 = "0.10"
 strum = { version = "0.26", features = ["strum_macros", "derive"] }
-tokio = { version = "1.41", optional = true }
+tokio = { version = "1.44", optional = true }
 url = { version = "2.5", optional = true }
 
 [features]
@@ -35,5 +35,5 @@ sso = ["session", "dep:serde", "dep:serde_json"]
 serde = ["dep:serde", "num-bigint/serde", "chrono/serde", "enum-map/serde"]
 
 [dev-dependencies]
-tokio = { version = "1.41", features = ["full"] }
-env_logger = "0.11.5"
+tokio = { version = "1.44", features = ["full"] }
+env_logger = "0.11.6"


### PR DESCRIPTION
Update most dependencies. 

Strum has a new 0.27 version, but we leak the strum traits to the user (should probably not have done that in hindsight), so upgrading strum would be a breaking change, that requires all users to update their strum as well. There is a ">=" "<" notation for dependencies, which might be able to capture 0.26 and 0.27, but i have not looked enough into that to be confident enough to do that. If anyone is reading this ever and knows more, please just comment on this PR