### PR TITLE
Fix toilet used status

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -259,22 +259,6 @@ impl GameState {
                 "wagesperhour" => {
                     self.tavern.guard_wage = val.into("tavern wage")?;
                 }
-                "toilettfull" => {
-                    // TODO: check if this is still available and check with
-                    // toiletstate
-
-                    let used = val.into::<i32>("toilet full status")? != 0;
-
-                    // This response is sent, even if the toilet is locked. A
-                    // default toilet should therefore only be inserted if the
-                    // toilet was actually used.
-                    if used {
-                        self.tavern
-                            .toilet
-                            .get_or_insert_with(Default::default)
-                            .used = used;
-                    }
-                }
                 "skipallow" => {
                     let raw_skip = val.into::<i32>("skip allow")?;
                     self.tavern.mushroom_skip_allowed = raw_skip != 0;
@@ -327,13 +311,15 @@ impl GameState {
                     clippy::cast_sign_loss,
                     clippy::cast_possible_truncation
                 )]
+                #[allow(deprecated)]
                 "toiletstate" => {
                     let vals: Vec<i64> = val.into_list("toilet state")?;
                     if vals.len() < 3 {
                         continue;
                     }
                     let toilet = self.tavern.toilet.get_or_insert_default();
-                    toilet.sacrificed_today = vals[2] as u32;
+                    toilet.sacrifices_left = vals[2] as u32;
+                    toilet.used = toilet.sacrifices_left == 0;
                 }
                 "companionequipment" => {
                     let data: Vec<i64> = val.into_list("quest items")?;

--- a/src/gamestate/tavern.rs
+++ b/src/gamestate/tavern.rs
@@ -296,7 +296,8 @@ impl CurrentAction {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The unlocked toilet, that you can throw items into
 pub struct Toilet {
-    /// Has the toilet been used today?
+    // Checks if all sacrifices today have been used up
+    #[deprecated(note = "You should use sacrifices_left instead")]
     pub used: bool,
     /// The level the aura is at currently
     pub aura: u32,
@@ -304,8 +305,8 @@ pub struct Toilet {
     pub mana_currently: u32,
     /// The total amount of mana you have to collect to flush the toilet
     pub mana_total: u32,
-    // The amount of items can be trown into the toilet
-    pub sacrificed_today: u32,
+    // The amount of sacrifices you have left today
+    pub sacrifices_left: u32,
 }
 
 impl Toilet {

--- a/src/sso.rs
+++ b/src/sso.rs
@@ -371,7 +371,7 @@ impl ServerLookup {
         }
 
         let resp: ServerResp = serde_json::from_str(&res).map_err(|_| {
-            SFError::ParsingError("server response", res.to_string())
+            SFError::ParsingError("server response", res.clone())
         })?;
 
         let servers: HashMap<i32, Url> = resp


### PR DESCRIPTION
They retired the old system. Since you can now have N sacrifices, instead of just 1, there is now a `sacrifices_left`, which will replace used