### PR TITLE
Fix lost equipment

### DIFF
--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -1066,6 +1066,7 @@ impl GameState {
                         op.wall_combat_lvl = oop.wall_combat_lvl;
                         op.fortress_rank = oop.fortress_rank;
                         op.soldier_advice = oop.soldier_advice;
+                        op.equipment = oop.equipment;
                     }
                     other_player = Some(op);
                 }


### PR DESCRIPTION
Since the processing order of each response field isn't guaranteed, this can - sometimes -  cause parsed equipment items to be *lost*. This specifically happens if equipment items are parsed and set, **before** this code block runs.

Also affects `sf-scrapbook-helper` causing players to have 0 items.