### PR TITLE
style: Standardize doc comment placement above attributes

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -21,10 +21,10 @@ use crate::{
     },
 };
 
+/// A command, that can be send to the sf server
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A command, that can be send to the sf server
 pub enum Command {
     /// If there is a command you somehow know/reverse engineered, or need to
     /// extend the functionality of one of the existing commands, this is the
@@ -51,11 +51,11 @@ pub enum Command {
         /// for logging in again after error
         login_count: u32,
     },
-    #[cfg(feature = "sso")]
     /// Manually sends a login request to the server.
     /// **WARN:** The behaviour for a credentials mismatch, with the
     /// credentials in the user is undefined. Use the login method instead for
     /// a safer abstraction
+    #[cfg(feature = "sso")]
     #[deprecated = "Use a login method instead"]
     SSOLogin {
         /// The Identifies the S&F account, that has this character
@@ -746,9 +746,9 @@ pub enum Command {
     BuyGoldFrame,
 }
 
+/// This is the "Questing instead of expeditions" value in the settings
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// This is the "Questing instead of expeditions" value in the settings
 pub enum ExpeditionSetting {
     /// When expeditions are available, this setting will enable expeditions to
     /// be started. This will disable questing, until either this setting is
@@ -781,19 +781,19 @@ pub enum FortunePayment {
     FreeTurn,
 }
 
+/// The price you have to pay to roll the dice
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The price you have to pay to roll the dice
 pub enum RollDicePrice {
     Free = 0,
     Mushrooms,
     Hourglass,
 }
 
+/// The type of dice you want to play with.
 #[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of dice you want to play with.
 pub enum DiceType {
     /// This means you want to discard whatever dice was previously at this
     /// position. This is also the type you want to fill the array with, if you
@@ -806,6 +806,7 @@ pub enum DiceType {
     Arcane,
     Hourglass,
 }
+
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DiceReward {
@@ -815,12 +816,12 @@ pub struct DiceReward {
     pub amount: u32,
 }
 
+/// A type of attribute
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Enum, FromPrimitive, Hash, EnumIter,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// A type of attribute
 pub enum AttributeType {
     Strength = 1,
     Dexterity = 2,
@@ -829,20 +830,20 @@ pub enum AttributeType {
     Luck = 5,
 }
 
+/// A type of shop. This is a subset of `ItemPlace`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Enum, EnumIter, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// A type of shop. This is a subset of `ItemPlace`
 pub enum ShopType {
     #[default]
     Weapon = 3,
     Magic = 4,
 }
 
+/// The "currency" you want to use to skip a quest
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The "currency" you want to use to skip a quest
 pub enum TimeSkip {
     Mushroom = 1,
     Glass = 2,
@@ -1483,10 +1484,10 @@ impl Command {
 
 macro_rules! generate_flag_enum {
     ($($variant:ident => $code:expr),*) => {
+        /// The flag of a country, that will be visible in the Hall of Fame
         #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumIter)]
         #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
         #[allow(missing_docs)]
-        /// The flag of a country, that will be visible in the Hall of Fame
         pub enum Flag {
             $(
                 $variant,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,10 @@
 use std::{error::Error, fmt::Display};
 
+/// An error, that occurred during the communication (sending/receiving/parsing)
+/// of requests to the S&F server
 #[derive(Debug)]
 #[non_exhaustive]
 #[allow(clippy::module_name_repetitions)]
-/// An error, that occurred during the communication (sending/receiving/parsing)
-/// of requests to the S&F server
 pub enum SFError {
     /// Whatever you were trying to send was not possible to send. This is
     /// either our issue when you were doing something normal, or you were

--- a/src/gamestate/arena.rs
+++ b/src/gamestate/arena.rs
@@ -4,9 +4,9 @@ use num_traits::FromPrimitive;
 use super::{items::*, *};
 use crate::PlayerId;
 
+/// The arena, that a player can fight other players in
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The arena, that a player can fight other players in
 pub struct Arena {
     /// The enemies currently available in the arena. You have to fetch the
     /// full player info before fighting them, as you need their name
@@ -18,10 +18,10 @@ pub struct Arena {
     pub fights_for_xp: u8,
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A complete fight, which can be between multiple fighters for guild/tower
 /// fights
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fight {
     /// The name of the attacking player for pet battles, or the name of the
     /// attacking guild in guild battles
@@ -101,10 +101,10 @@ impl Fight {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// This is a single fight between two fighters, which ends when one of them is
 /// at <= 0 health
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SingleFight {
     /// The ID of the player, that won.
     pub winner_id: PlayerId,
@@ -169,10 +169,10 @@ impl SingleFight {
     }
 }
 
-#[derive(Debug, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// A participant in a fight. Can be anything, that shows up in the battle
 /// screen from the player to a fortress Wall
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Fighter {
     /// The type of the fighter
     pub typ: FighterTyp,
@@ -258,9 +258,9 @@ impl Fighter {
     }
 }
 
+/// One round (action) in a fight. This is mostly just one attack
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// One round (action) in a fight. This is mostly just one attack
 pub struct FightAction {
     /// The id of the fighter, that does the action
     pub acting_id: i64,
@@ -272,11 +272,11 @@ pub struct FightAction {
     pub action: FightActionType,
 }
 
-#[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// An action in a fight. In the official client this determines the animation,
 /// that gets played
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum FightActionType {
     /// A simple attack with the normal weapon
     Attack,
@@ -319,12 +319,12 @@ impl FightActionType {
     }
 }
 
+/// The type of the participant in a fight
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The type of the participant in a fight
 pub enum FighterTyp {
-    #[default]
     /// Not just the own player, but any player on the server
+    #[default]
     Player,
     /// A generic monster, or dungeon boss with its `monster_id`
     Monster(u16),

--- a/src/gamestate/character.rs
+++ b/src/gamestate/character.rs
@@ -8,10 +8,10 @@ use num_traits::FromPrimitive;
 use super::{Mirror, NormalCost, RelationEntry, SFError, ScrapBook};
 use crate::{PlayerId, command::*, gamestate::items::*, misc::*};
 
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Everything, that can be considered part of the character and not the rest
 /// of the world
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Character {
     /// This is the unique identifier of this character. Can be used to compare
     /// against places, that also have `player_ids` to make sure a Hall of

--- a/src/gamestate/dungeons.rs
+++ b/src/gamestate/dungeons.rs
@@ -16,9 +16,9 @@ use crate::{
     },
 };
 
+/// The personal demon portal
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The personal demon portal
 pub struct Portal {
     /// The amount of enemies you have fought in the portal already
     pub finished: u16,
@@ -52,10 +52,10 @@ impl Portal {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The information about all generic dungeons in the game. Information about
 /// special dungeons like the portal
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Dungeons {
     /// The next time you can fight in the dungeons for free
     pub next_free_fight: Option<DateTime<Local>>,
@@ -92,12 +92,12 @@ impl Dungeons {
     }
 }
 
+/// The current state of a dungeon
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The current state of a dungeon
 pub enum DungeonProgress {
-    #[default]
     /// The dungeon has not yet been unlocked
+    #[default]
     Locked,
     /// The dungeon is open and can be fought in
     Open {
@@ -108,26 +108,29 @@ pub enum DungeonProgress {
     Finished,
 }
 
+/// The category of a dungeon. This is only used internally, so there is no
+/// real point for you to use this
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The category of a dungeon. This is only used internally, so there is no
-/// real point for you to use this
 pub enum DungeonType {
     Light,
     Shadow,
 }
 
+/// The category of a dungeon. This is only used internally, so there is no
+/// real point for you to use this
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The category of a dungeon. This is only used internally, so there is no
-/// real point for you to use this
 pub enum Dungeon {
     Light(LightDungeon),
     Shadow(ShadowDungeon),
 }
 
+/// All possible light dungeons. They are NOT numbered continuously (17 is
+/// missing), so you should use `LightDungeon::iter()`, if you want to iterate
+/// these
 #[derive(
     Debug,
     Clone,
@@ -142,9 +145,6 @@ pub enum Dungeon {
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// All possible light dungeons. They are NOT numbered continuously (17 is
-/// missing), so you should use `LightDungeon::iter()`, if you want to iterate
-/// these
 pub enum LightDungeon {
     DesecratedCatacombs = 0,
     MinesOfGloria = 1,
@@ -190,6 +190,8 @@ impl From<LightDungeon> for Dungeon {
     }
 }
 
+/// All possible shadow dungeons. You can use `ShadowDungeon::iter()`, if you
+/// want to iterate these
 #[derive(
     Debug,
     Clone,
@@ -204,8 +206,6 @@ impl From<LightDungeon> for Dungeon {
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// All possible shadow dungeons. You can use `ShadowDungeon::iter()`, if you
-/// want to iterate these
 pub enum ShadowDungeon {
     DesecratedCatacombs = 0,
     MinesOfGloria = 1,
@@ -314,12 +314,12 @@ impl Dungeons {
     }
 }
 
+/// The class of a companion. There is only 1 companion per class, so this is
+/// also a ident of the characters
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, EnumCount, Enum, EnumIter, Hash,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The class of a companion. There is only 1 companion per class, so this is
-/// also a ident of the characters
 pub enum CompanionClass {
     /// Bert
     Warrior = 0,
@@ -339,10 +339,10 @@ impl From<CompanionClass> for Class {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// All the information about a single companion. The class is not included
 /// here, as you access this via a map, where the key will be the class
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Companion {
     /// I can not recall, if I made this signed on purpose, because this should
     /// always be > 0

--- a/src/gamestate/fortress.rs
+++ b/src/gamestate/fortress.rs
@@ -15,9 +15,9 @@ use crate::{
     misc::soft_into,
 };
 
+/// The information about a characters fortress
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The information about a characters fortress
 pub struct Fortress {
     /// All the buildings, that a fortress can have. If they are not yet built,
     /// they are level 0
@@ -79,10 +79,10 @@ pub struct Fortress {
     pub secret_storage_wood: u64,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The price an upgrade, or building something in the fortress costs. These
 /// are always for one upgrade/build, which is important for unit builds
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FortressCost {
     /// The time it takes to complete one build/upgrade
     pub time: Duration,
@@ -106,9 +106,9 @@ impl FortressCost {
     }
 }
 
+/// Information about one of the three resources, that the fortress can produce.
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about one of the three resources, that the fortress can produce.
 pub struct FortressResource {
     /// The amount of this resource you have available to spend on upgrades and
     /// recruitment
@@ -120,10 +120,10 @@ pub struct FortressResource {
     pub production: FortressProduction,
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Information about the production of a resource in the fortress.  Note that
 /// experience will not have some of these fields
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FortressProduction {
     /// The amount the production building has already produced, that you can
     /// collect. Note that this value will be out of date by some amount of
@@ -141,22 +141,22 @@ pub struct FortressProduction {
     pub per_hour_next_lvl: u64,
 }
 
+/// The type of resource, that the fortress available in the fortress
 #[derive(Debug, Clone, Copy, EnumCount, EnumIter, PartialEq, Eq, Enum)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of resource, that the fortress available in the fortress
 pub enum FortressResourceType {
     Wood = 0,
     Stone = 1,
     Experience = 2,
 }
 
+/// The type of building, that can be build in the fortress
 #[derive(
     Debug, Clone, Copy, EnumCount, FromPrimitive, PartialEq, Eq, Enum, EnumIter,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of building, that can be build in the fortress
 pub enum FortressBuildingType {
     Fortress = 0,
     LaborersQuarters = 1,
@@ -208,9 +208,9 @@ impl FortressBuildingType {
     }
 }
 
+/// Information about a single type of unit
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about a single type of unit
 pub struct FortressUnit {
     /// The level this unit has
     pub level: u16,
@@ -230,10 +230,10 @@ pub struct FortressUnit {
     pub upgrade_next_lvl: u64,
 }
 
-#[derive(Debug, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// An action, that costs some amount of resources to do and will finish at a
 /// certain point in time
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FortressAction<T> {
     /// When this action was started. This can be months in the past, as this
     /// will often not be cleared by the server
@@ -258,20 +258,20 @@ impl<T> Default for FortressAction<T> {
     }
 }
 
+/// The type of a unit usable in the fortress
 #[derive(Debug, Clone, Copy, EnumCount, PartialEq, Eq, Enum, EnumIter)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of a unit usable in the fortress
 pub enum FortressUnitType {
     Soldier = 0,
     Magician = 1,
     Archer = 2,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Generic information about a building in the fortress. If you want
 /// information about a production building, you should look at the resources
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct FortressBuilding {
     /// The current level of this building. If this is 0, it has not yet been
     /// build

--- a/src/gamestate/guild.rs
+++ b/src/gamestate/guild.rs
@@ -12,9 +12,9 @@ use super::{
 };
 use crate::misc::{from_sf_string, soft_into, warning_parse};
 
+/// Information about the characters current guild
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the characters current guild
 pub struct Guild {
     /// The internal server id of this guild
     pub id: u32,
@@ -83,9 +83,9 @@ pub struct Guild {
     pub fightable_guilds: Vec<FightableGuild>,
 }
 
+/// The hydra, that the guild pet can fight
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The hydra, that the guild pet can fight
 pub struct GuildHydra {
     /// The last time the hydra has been fought
     pub last_battle: Option<DateTime<Local>>,
@@ -129,9 +129,9 @@ pub struct FightableGuild {
     pub honor: u32,
 }
 
+/// The customizable emblem each guild has
 #[derive(Debug, Clone, Default, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The customizable emblem each guild has
 pub struct Emblem {
     raw: String,
 }
@@ -150,9 +150,9 @@ impl Emblem {
     }
 }
 
+/// A message, that the player has received, or has send to others via the chat
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A message, that the player has received, or has send to others via the chat
 pub struct ChatMessage {
     /// The user this message originated from. Note that this might not be in
     /// the guild member list in some cases
@@ -414,9 +414,9 @@ impl Guild {
     }
 }
 
+/// A guild battle, that is scheduled to take place at a certain place and time
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A guild battle, that is scheduled to take place at a certain place and time
 pub struct PlanedBattle {
     /// The guild this battle will be against
     pub other: u32,
@@ -450,9 +450,9 @@ impl PlanedBattle {
     }
 }
 
+/// The portal a guild has
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The portal a guild has
 pub struct GuildPortal {
     /// The damage bonus in percent the guild portal gives to its members
     pub damage_bonus: u8,
@@ -462,9 +462,10 @@ pub struct GuildPortal {
     /// The percentage of life the portal enemy still has
     pub life_percentage: u8,
 }
+
+/// Which battles a member will participate in
 #[derive(Debug, Copy, Clone, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Which battles a member will participate in
 pub enum BattlesJoined {
     /// The player has only joined the defense of the guild
     Defense = 1,
@@ -475,9 +476,9 @@ pub enum BattlesJoined {
     Both = 11,
 }
 
+/// A member of a guild
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A member of a guild
 pub struct GuildMemberData {
     /// The name of the member
     pub name: String,
@@ -508,10 +509,10 @@ pub struct GuildMemberData {
     pub knights: u8,
 }
 
+/// The rank a member can have in a guild
 #[derive(Debug, Clone, Copy, FromPrimitive, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The rank a member can have in a guild
 pub enum GuildRank {
     Leader = 1,
     Officer = 2,
@@ -520,9 +521,9 @@ pub enum GuildRank {
     Invited = 4,
 }
 
+/// Something the player can upgrade in the guild
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Something the player can upgrade in the guild
 #[allow(missing_docs)]
 pub enum GuildSkill {
     Treasure = 0,

--- a/src/gamestate/idle.rs
+++ b/src/gamestate/idle.rs
@@ -6,9 +6,9 @@ use strum::EnumIter;
 
 use super::ServerTime;
 
+/// The idle clicker game where you invest money and get runes by sacrificing
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The idle clicker game where you invest money and get runes by sacrificing
 pub struct IdleGame {
     /// The current amount of money the player
     pub current_money: BigInt,
@@ -30,9 +30,9 @@ pub struct IdleGame {
     pub buildings: EnumMap<IdleBuildingType, IdleBuilding>,
 }
 
+/// A single building in the idle game
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A single building in the idle game
 pub struct IdleBuilding {
     /// The current level of this building
     pub level: u32,
@@ -101,10 +101,10 @@ impl IdleGame {
     }
 }
 
+/// The type of a building in the idle game
 #[derive(Debug, Clone, Copy, Enum, EnumIter, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of a building in the idle game
 pub enum IdleBuildingType {
     Seat = 1,
     PopcornStand,

--- a/src/gamestate/items.rs
+++ b/src/gamestate/items.rs
@@ -16,9 +16,9 @@ use crate::{
     gamestate::{CCGet, CGet, ShopPosition},
 };
 
+/// The basic inventory, that every player has
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The basic inventory, that every player has
 pub struct Inventory {
     pub backpack: Vec<Option<Item>>,
 }
@@ -60,11 +60,11 @@ impl Inventory {
         self.backpack.split_at(5)
     }
 
-    #[must_use]
     // Splits the backpack, as if it was the old bag/fortress chest layout.
     // The first slice will be the bag, the second the fortress chest
     // If the backback if empty for unknown reasons, or is shorter than 5
     // elements, both slices will be emptys
+    #[must_use]
     pub fn as_split_mut(
         &mut self,
     ) -> (&mut [Option<Item>], &mut [Option<Item>]) {
@@ -101,10 +101,10 @@ impl Inventory {
     }
 }
 
+/// All the parts of `ItemPlace`, that are owned by the player
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// All the parts of `ItemPlace`, that are owned by the player
 pub enum PlayerItemPlace {
     Equipment = 1,
     MainInventory = 2,
@@ -196,10 +196,10 @@ impl PlayerItemPlace {
     }
 }
 
+/// All the parts of `ItemPlace`, that are owned by the player
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// All the parts of `ItemPlace`, that are owned by the player
 pub enum InventoryType {
     MainInventory = 2,
     ExtendedInventory = 5,
@@ -228,9 +228,9 @@ impl InventoryType {
     }
 }
 
+/// All places, that items can be dragged to excluding companions
 #[derive(Debug, Clone, Copy, PartialEq, Eq, EnumIter, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// All places, that items can be dragged to excluding companions
 pub enum ItemPlace {
     /// The stuff a player can wear
     Equipment = 1,
@@ -244,9 +244,9 @@ pub enum ItemPlace {
     FortressChest = 5,
 }
 
+/// All the equipment a player is wearing
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// All the equipment a player is wearing
 pub struct Equipment(pub EnumMap<EquipmentSlot, Option<Item>>);
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Copy)]
@@ -272,8 +272,8 @@ impl Equipment {
             .map(|(pos, item)| (EquipmentPosition(pos), item.as_ref()))
     }
 
-    #[must_use]
     /// Checks if the character has an item with the enchantment equipped
+    #[must_use]
     pub fn has_enchantment(&self, enchantment: Enchantment) -> bool {
         let item = self.0.get(enchantment.equipment_slot());
         if let Some(item) = item {
@@ -306,10 +306,10 @@ impl Equipment {
 
 pub(crate) const ITEM_PARSE_LEN: usize = 19;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Information about a single item. This can be anything, that is either in a
 /// inventory, in a reward slot, or similar
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Item {
     /// The type of this item. May contain further type specific values
     pub typ: ItemType,
@@ -589,11 +589,11 @@ impl Item {
     }
 }
 
+/// A enchantment, that gives a bonus to an aspect, if the item
 #[derive(
     Debug, Clone, Copy, FromPrimitive, PartialEq, Eq, EnumIter, Hash, Enum,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A enchantment, that gives a bonus to an aspect, if the item
 pub enum Enchantment {
     /// Increased crit damage
     SwordOfVengeance = 11,
@@ -632,9 +632,9 @@ impl Enchantment {
     }
 }
 
+/// A rune, which has both a type and a strength
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A rune, which has both a type and a strength
 pub struct Rune {
     /// The type of tune this is
     pub typ: RuneType,
@@ -662,9 +662,9 @@ pub enum RuneType {
     LightningDamage,
 }
 
+/// A gem slot for an item
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A gem slot for an item
 pub enum GemSlot {
     /// This gemslot has been filled and can only be emptied by the blacksmith
     Filled(Gem),
@@ -691,9 +691,10 @@ impl GemSlot {
         }
     }
 }
+
+/// A potion. This is not just itemtype to make active potions easier
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A potion. This is not just itemtype to make active potions easier
 pub struct Potion {
     /// The rtype of potion
     pub typ: PotionType,
@@ -704,12 +705,12 @@ pub struct Potion {
     pub expires: Option<DateTime<Local>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[allow(missing_docs)]
 /// Identifies a specific item and contains all values related to the specific
 /// type. The only thing missing is armor, which can be found as a method on
 /// `Item`
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[allow(missing_docs)]
 pub enum ItemType {
     Hat,
     BreastPlate,
@@ -985,10 +986,10 @@ impl ItemType {
     }
 }
 
+/// The effect, that the potion is going to have
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The effect, that the potion is going to have
 pub enum PotionType {
     Strength,
     Dexterity,
@@ -1028,10 +1029,10 @@ impl PotionType {
     }
 }
 
+/// The size and with that, the strength, that this potion has
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The size and with that, the strength, that this potion has
 pub enum PotionSize {
     Small,
     Medium,
@@ -1064,10 +1065,10 @@ impl PotionSize {
     }
 }
 
+/// Differentiates resource items
 #[derive(Debug, Clone, PartialEq, Eq, Copy, FromPrimitive)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// Differentiates resource items
 pub enum ResourceType {
     Wood = 17,
     Stone,
@@ -1076,9 +1077,9 @@ pub enum ResourceType {
     Metal,
 }
 
+/// A gem, that is either socketed in an item, or in the inventory
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A gem, that is either socketed in an item, or in the inventory
 pub struct Gem {
     /// The type of gem
     pub typ: GemType,
@@ -1086,10 +1087,10 @@ pub struct Gem {
     pub value: u32,
 }
 
+/// The type the gam has
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type the gam has
 pub enum GemType {
     Strength,
     Dexterity,
@@ -1126,12 +1127,12 @@ impl GemType {
     }
 }
 
+/// Denotes the place, where an item is equipped
 #[derive(
     Debug, Copy, Clone, PartialEq, Eq, Hash, Enum, EnumIter, EnumCount,
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// Denotes the place, where an item is equipped
 pub enum EquipmentSlot {
     Hat = 1,
     BreastPlate,
@@ -1185,10 +1186,10 @@ impl EquipmentSlot {
     }
 }
 
+/// An item usable for pets
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// An item usable for pets
 pub enum PetItem {
     Egg(HabitatType),
     SpecialEgg(HabitatType),

--- a/src/gamestate/mod.rs
+++ b/src/gamestate/mod.rs
@@ -31,9 +31,9 @@ use crate::{
     response::Response,
 };
 
+/// Represent the full state of the game at some point in time
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Represent the full state of the game at some point in time
 pub struct GameState {
     /// Everything, that can be considered part of the character, or his
     /// immediate surrounding and not the rest of the world
@@ -86,9 +86,10 @@ pub struct GameState {
 }
 
 const SHOP_N: usize = 6;
+
+/// A shop, that you can buy items from
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A shop, that you can buy items from
 pub struct Shop {
     pub typ: ShopType,
     /// The items this shop has for sale
@@ -1929,9 +1930,9 @@ impl StringSetExt for String {
     }
 }
 
+/// The cost of something
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The cost of something
 pub struct NormalCost {
     /// The amount of silver something costs
     pub silver: u64,

--- a/src/gamestate/rewards.rs
+++ b/src/gamestate/rewards.rs
@@ -12,12 +12,12 @@ use super::{
 };
 use crate::{command::AttributeType, error::SFError};
 
+/// The type of a reward you can win by spinning the wheel. The wheel can be
+/// upgraded, so some rewards may not always be available
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[non_exhaustive]
 #[allow(missing_docs)]
-/// The type of a reward you can win by spinning the wheel. The wheel can be
-/// upgraded, so some rewards may not always be available
 pub enum WheelRewardType {
     Mushrooms,
     Stone,
@@ -35,9 +35,9 @@ pub enum WheelRewardType {
     Unknown,
 }
 
+/// The thing you won from spinning the wheel
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The thing you won from spinning the wheel
 pub struct WheelReward {
     /// The type of item you have won
     pub typ: WheelRewardType,
@@ -106,9 +106,9 @@ impl WheelReward {
     }
 }
 
+/// A possible reward on the calendar
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A possible reward on the calendar
 pub struct CalendarReward {
     /// Note that this is technically correct, but at low levels, these are
     /// often overwritten to silver
@@ -118,10 +118,10 @@ pub struct CalendarReward {
     pub amount: i64,
 }
 
+/// The type of reward gainable by collecting the calendar
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of reward gainable by collecting the calendar
 pub enum CalendarRewardType {
     Silver,
     Mushrooms,
@@ -186,9 +186,9 @@ impl CalendarReward {
     }
 }
 
+/// Everything, that changes over time
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Everything, that changes over time
 pub struct TimedSpecials {
     /// All of the events active in the tavern
     pub events: Events,
@@ -200,9 +200,9 @@ pub struct TimedSpecials {
     pub wheel: Wheel,
 }
 
+/// Information about the events active in the tavern
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the events active in the tavern
 pub struct Events {
     /// All of the events active in the tavern
     pub active: HashSet<Event>,
@@ -210,10 +210,10 @@ pub struct Events {
     pub ends: Option<DateTime<Local>>,
 }
 
+/// Grants rewards once a day
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[doc(alias = "DailyLoginBonus")]
-/// Grants rewards once a day
 pub struct Calendar {
     /// The amount of times the calendar has been collected already.
     /// `rewards[collected]` will give you the position in the rewards you will
@@ -226,9 +226,9 @@ pub struct Calendar {
     pub next_possible: Option<DateTime<Local>>,
 }
 
+/// The tasks you get from the goblin gleeman
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The tasks you get from the goblin gleeman
 pub struct Tasks {
     /// The tasks, that update daily
     pub daily: DailyTasks,
@@ -236,9 +236,9 @@ pub struct Tasks {
     pub event: EventTasks,
 }
 
+/// Information about the tasks, that reset every day
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the tasks, that reset every day
 pub struct DailyTasks {
     /// The tasks you have to do
     pub tasks: Vec<Task>,
@@ -246,9 +246,9 @@ pub struct DailyTasks {
     pub rewards: [RewardChest; 3],
 }
 
+/// Information about the tasks, that are based on some event theme
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the tasks, that are based on some event theme
 pub struct EventTasks {
     /// The "theme" the event task has. This is mainly irrelevant
     pub theme: EventTaskTheme,
@@ -336,9 +336,9 @@ impl Task {
     }
 }
 
+/// Dr. Abawuwu's wheel
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Dr. Abawuwu's wheel
 pub struct Wheel {
     /// The amount of lucky coins you have to spin the weel
     pub lucky_coins: u32,
@@ -350,11 +350,11 @@ pub struct Wheel {
     pub result: Option<WheelReward>,
 }
 
-#[non_exhaustive]
+/// The theme the event tasks have
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 #[allow(missing_docs)]
-/// The theme the event tasks have
 pub enum EventTaskTheme {
     // 1 is not set
     Gambler = 2,
@@ -378,11 +378,11 @@ pub enum EventTaskTheme {
     Unknown = 245,
 }
 
-#[non_exhaustive]
+/// The type of task you have to do
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 #[allow(missing_docs)]
-/// The type of task you have to do
 pub enum TaskType {
     AddSocketToItem,
     BlacksmithDismantle,
@@ -619,9 +619,9 @@ impl TaskType {
     }
 }
 
+/// Something to do to get a point reward
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Something to do to get a point reward
 pub struct Task {
     /// The thing you are tasked with doing or getting for this task
     pub typ: TaskType,
@@ -650,9 +650,9 @@ impl Task {
     }
 }
 
+/// Something you can unlock for completing tasks
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Something you can unlock for completing tasks
 pub struct RewardChest {
     /// Whether or not this chest has been unlocked
     pub opened: bool,
@@ -662,9 +662,9 @@ pub struct RewardChest {
     pub rewards: Vec<Reward>,
 }
 
+/// The reward for opening a chest
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The reward for opening a chest
 pub struct Reward {
     /// The type of the thing you are getting
     pub typ: RewardType,
@@ -772,10 +772,10 @@ impl RewardChest {
     }
 }
 
+/// The type of event, that is currently happening on the server
 #[derive(Debug, Clone, Copy, FromPrimitive, PartialEq, Eq, Hash, EnumIter)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of event, that is currently happening on the server
 pub enum Event {
     ExceptionalXPEvent = 0,
     GloriousGoldGalore,

--- a/src/gamestate/social.rs
+++ b/src/gamestate/social.rs
@@ -37,10 +37,10 @@ pub struct Mail {
     pub open_claimable: Option<ClaimablePreview>,
 }
 
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Contains information about everything involving other players on the server.
 /// This mainly revolves around the Hall of Fame
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HallOfFames {
     /// The amount of accounts on the server
     pub players_total: u32,
@@ -83,10 +83,10 @@ pub struct HallOfFameHellevator {
     pub tokens: u64,
 }
 
-#[derive(Debug, Clone, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Contains the results of `ViewGuild` & `ViewPlayer` commands. You can access
 /// the player info via functions and the guild data directly
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Lookup {
     /// This can be accessed by using the `lookup_pid()`/`lookup_name()`
     /// methods on `Lookup`
@@ -140,10 +140,10 @@ impl Lookup {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Basic information about one character on the server. To get more
 /// information, you need to query this player via the `ViewPlayer` command
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HallOfFamePlayer {
     /// The rank of this player
     pub rank: u32,
@@ -195,10 +195,10 @@ impl HallOfFamePlayer {
     }
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Basic information about one guild on the server. To get more information,
 /// you need to query this player via the `ViewGuild` command
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HallOfFameGuild {
     /// The name of the guild
     pub name: String,
@@ -299,9 +299,9 @@ impl HallOfFameUnderworld {
     }
 }
 
+/// Basic information about one guild on the server
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Basic information about one guild on the server
 pub struct HallOfFameFortress {
     /// The name of the person, that owns this fort
     pub name: String,
@@ -316,9 +316,9 @@ pub struct HallOfFameFortress {
     pub honor: u32,
 }
 
+/// Basic information about one players pet collection on the server
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Basic information about one players pet collection on the server
 pub struct HallOfFamePets {
     /// The name of the player, that has these pets
     pub name: String,
@@ -336,9 +336,9 @@ pub struct HallOfFamePets {
     pub unknown: i64,
 }
 
+/// Basic information about one players underworld on the server
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Basic information about one players underworld on the server
 pub struct HallOfFameUnderworld {
     /// The rank this underworld has
     pub rank: u32,
@@ -356,10 +356,10 @@ pub struct HallOfFameUnderworld {
     pub unknown: i64,
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// All information about another player, that was queried via the `ViewPlayer`
 /// command
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OtherPlayer {
     /// The id of this player. This is mainly just useful to lookup this player
     /// in `Lookup`, if you do not know the name

--- a/src/gamestate/tavern.rs
+++ b/src/gamestate/tavern.rs
@@ -13,9 +13,9 @@ use crate::{
     misc::soft_into,
 };
 
+/// Anything related to things you can do in the tavern
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Anything related to things you can do in the tavern
 pub struct Tavern {
     /// All the available quests
     pub quests: [Quest; 3],
@@ -47,9 +47,9 @@ pub struct Tavern {
     pub beer_max: u8,
 }
 
+/// Information about everything related to expeditions
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about everything related to expeditions
 pub struct ExpeditionsEvent {
     /// The time the expeditions mechanic was enabled at
     pub start: Option<DateTime<Local>>,
@@ -88,9 +88,9 @@ impl ExpeditionsEvent {
     }
 }
 
+/// Information about the current state of the dice game
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the current state of the dice game
 pub struct DiceGame {
     /// The amount of dice games you can still play today
     pub remaining: u8,
@@ -103,11 +103,11 @@ pub struct DiceGame {
     pub reward: Option<DiceReward>,
 }
 
-#[derive(Debug, Clone)]
-#[allow(missing_docs)]
 /// The tasks you will presented with, when clicking the person in the tavern.
 /// Make sure you are not currently busy and have enough ALU/thirst of adventure
 /// before trying to start them
+#[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub enum AvailableTasks<'a> {
     Quests(&'a [Quest; 3]),
     Expeditions(&'a [AvailableExpedition]),
@@ -172,9 +172,9 @@ impl Tavern {
     }
 }
 
+/// One of the three possible quests in the tavern
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// One of the three possible quests in the tavern
 pub struct Quest {
     /// The length of this quest in sec (without item enchantment)
     pub base_length: u32,
@@ -190,10 +190,10 @@ pub struct Quest {
     pub monster_id: u16,
 }
 
+/// The background/location for a quest, or another activity
 #[derive(Debug, Default, Clone, PartialEq, Eq, Copy, FromPrimitive, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The background/location for a quest, or another activity
 pub enum Location {
     #[default]
     SprawlingJungle = 1,
@@ -239,12 +239,12 @@ impl Quest {
     }
 }
 
+/// The thing the player is currently doing
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The thing the player is currently doing
 pub enum CurrentAction {
-    #[default]
     /// The character is not doing anything and can basically do anything
+    #[default]
     Idle,
     /// The character is working on guard duty right now. If `busy_until <
     /// Local::now()`, you can send a `WorkFinish` command
@@ -295,9 +295,9 @@ impl CurrentAction {
     }
 }
 
+/// The unlocked toilet, that you can throw items into
 #[derive(Debug, Clone, Default, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The unlocked toilet, that you can throw items into
 pub struct Toilet {
     // Checks if all sacrifices today have been used up
     #[deprecated(note = "You should use sacrifices_left instead")]
@@ -321,9 +321,9 @@ impl Toilet {
     }
 }
 
+/// The state of an ongoing expedition
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The state of an ongoing expedition
 pub struct Expedition {
     /// The items collected durign the expedition
     pub items: [Option<ExpeditionThing>; 4],
@@ -390,10 +390,10 @@ impl Expedition {
             .collect();
     }
 
-    #[must_use]
     /// Returns the current stage the player is doing. This is dependent on
     /// time, because the timers are lazily evaluated. That means it might
     /// flip from Waiting->Encounters/Finished between calls
+    #[must_use]
     pub fn current_stage(&self) -> ExpeditionStage {
         let cross_roads =
             || ExpeditionStage::Encounters(self.encounters.clone());
@@ -411,16 +411,16 @@ impl Expedition {
         }
     }
 
-    #[must_use]
     /// Checks, if the last timer of this expedition has run out
+    #[must_use]
     pub fn is_finished(&self) -> bool {
         matches!(self.current_stage(), ExpeditionStage::Finished)
     }
 }
 
+/// The current thing, that would be on screen, when using the web client
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The current thing, that would be on screen, when using the web client
 pub enum ExpeditionStage {
     /// Choose one of these rewards after winning against the boss
     Rewards(Vec<Reward>),
@@ -446,9 +446,9 @@ impl Default for ExpeditionStage {
     }
 }
 
+/// The monster you fight after 5 and 10 expedition encounters
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The monster you fight after 5 and 10 expedition encounters
 pub struct ExpeditionBoss {
     /// The monster id of this boss
     pub id: i64,
@@ -456,10 +456,10 @@ pub struct ExpeditionBoss {
     pub items: u8,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// One of up to three encounters you can find. In comparison to
 /// `ExpeditionThing`, this also includes the expected heroism
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ExpeditionEncounter {
     /// The type of thing you engage, or find on this path
     pub typ: ExpeditionThing,
@@ -468,10 +468,10 @@ pub struct ExpeditionEncounter {
     pub heroism: i32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, Default)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The type of something you can encounter on the expedition. Can also be found
 /// as the target, or in the items section
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs, clippy::doc_markdown)]
 pub enum ExpeditionThing {
     #[default]
@@ -549,10 +549,10 @@ pub enum ExpeditionThing {
 }
 
 impl ExpeditionThing {
-    #[must_use]
-    #[allow(clippy::enum_glob_use)]
     /// Returns the associated bounty item required to get a +10 bonus for
     /// picking up this item
+    #[must_use]
+    #[allow(clippy::enum_glob_use)]
     pub fn required_bounty(&self) -> Option<ExpeditionThing> {
         use ExpeditionThing::*;
         Some(match self {
@@ -571,10 +571,10 @@ impl ExpeditionThing {
         })
     }
 
-    #[must_use]
-    #[allow(clippy::enum_glob_use)]
     /// If the thing is a bounty, this will contain all the things, that receive
     /// a bonus
+    #[must_use]
+    #[allow(clippy::enum_glob_use)]
     pub fn is_bounty_for(&self) -> Option<&'static [ExpeditionThing]> {
         use ExpeditionThing::*;
         Some(match self {
@@ -594,9 +594,9 @@ impl ExpeditionThing {
     }
 }
 
+/// Information about a possible expedition, that you could start
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about a possible expedition, that you could start
 pub struct AvailableExpedition {
     /// The target, that will be collected during the expedition
     pub target: ExpeditionThing,
@@ -611,11 +611,11 @@ pub struct AvailableExpedition {
     pub location_2: Location,
 }
 
+/// The amount, that you either won or lost gambling. If the value is negative,
+/// you lost
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The amount, that you either won or lost gambling. If the value is negative,
-/// you lost
 pub enum GambleResult {
     SilverChange(i64),
     MushroomChange(i32),

--- a/src/gamestate/underworld.rs
+++ b/src/gamestate/underworld.rs
@@ -8,9 +8,9 @@ use strum::{EnumIter, IntoEnumIterator};
 
 use super::{ArrSkip, CCGet, CFPGet, CSTGet, EnumMapGet, SFError, ServerTime};
 
+/// The information about a characters underworld
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The information about a characters underworld
 pub struct Underworld {
     /// All the buildings, that the underworld can have. If they are not yet
     /// build, they are level 0
@@ -47,10 +47,10 @@ pub struct Underworld {
     pub lured_today: u16,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The price an upgrade, or building something in the underworld costs. These
 /// are always for one upgrade/build, which is important for unit builds
+#[derive(Debug, Default, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnderworldCost {
     /// The time it takes to complete one build/upgrade
     pub time: Duration,
@@ -160,10 +160,10 @@ impl Underworld {
     }
 }
 
+/// The type of a producible resource in the underworld
 #[derive(Debug, Clone, Copy, strum::EnumCount, Enum, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of a producible resource in the underworld
 pub enum UnderworldResourceType {
     Souls = 0,
     Silver = 1,
@@ -171,10 +171,10 @@ pub enum UnderworldResourceType {
     ThirstForAdventure = 2,
 }
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Information about the producion of a resource in the fortress.  Note that
 /// experience will not have some of these fields
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UnderworldProduction {
     /// The amount the production building has already produced, that you can
     /// collect. Note that this value will be out of date by some amount of
@@ -189,6 +189,7 @@ pub struct UnderworldProduction {
     pub per_hour: u64,
 }
 
+/// The type of building in the underworld
 #[derive(
     Debug,
     Clone,
@@ -201,7 +202,6 @@ pub struct UnderworldProduction {
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of building in the underworld
 pub enum UnderworldBuildingType {
     HeartOfDarkness = 0,
     Gate = 1,
@@ -215,19 +215,19 @@ pub enum UnderworldBuildingType {
     Keeper = 9,
 }
 
+/// The type of unit in the underworld
 #[derive(Debug, Clone, Copy, strum::EnumCount, Enum, EnumIter, PartialEq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[allow(missing_docs)]
-/// The type of unit in the underworld
 pub enum UnderworldUnitType {
     Goblin = 0,
     Troll = 1,
     Keeper = 2,
 }
 
+/// Information about the current building state of a building
 #[derive(Debug, Default, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about the current building state of a building
 pub struct UnderworldBuilding {
     /// The current level of this building. If this is 0, it has not yet been
     /// built
@@ -236,9 +236,9 @@ pub struct UnderworldBuilding {
     pub upgrade_cost: UnderworldCost,
 }
 
+/// Information about a single type of unit
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Information about a single type of unit
 pub struct UnderworldUnit {
     /// The current (battle) level this unit has
     pub level: u16,

--- a/src/gamestate/unlockables.rs
+++ b/src/gamestate/unlockables.rs
@@ -9,10 +9,10 @@ use strum::EnumIter;
 use super::*;
 use crate::{PlayerId, gamestate::items::*, misc::*};
 
-#[derive(Debug, Default, Clone)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Information about the Hellevator event on the server. If it is active, you
 /// can get more detailed info via `active()`
+#[derive(Debug, Default, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct HellevatorEvent {
     /// The time the hellevator event was enabled at
     pub start: Option<DateTime<Local>>,
@@ -400,10 +400,10 @@ pub struct Witch {
     pub enchantments: EnumMap<Enchantment, Option<EnchantmentIdent>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// The S&F server needs a character specific value for enchanting items. This
 /// is that value
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct EnchantmentIdent(pub(crate) NonZeroU8);
 
 impl Witch {
@@ -509,9 +509,9 @@ pub struct Habitat {
     pub pets: [Pet; PETS_PER_HABITAT],
 }
 
+/// Represents the current state of the habitat exploration
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Represents the current state of the habitat exploration
 pub enum HabitatExploration {
     #[default]
     /// Explored/won all 20 habitat battles. This means you can no longer fight
@@ -720,9 +720,9 @@ impl PetStats {
     }
 }
 
+/// The current state of the mirror
 #[derive(Debug, Clone, Copy, strum::EnumCount, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The current state of the mirror
 pub enum Mirror {
     /// The player is still collecting the mirror pieces
     Pieces {
@@ -775,9 +775,9 @@ impl Unlockable {
     }
 }
 
+/// The current progress towards all achievements
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The current progress towards all achievements
 pub struct Achievements(pub Vec<Achievement>);
 
 impl Achievements {
@@ -805,9 +805,9 @@ impl Achievements {
     }
 }
 
+/// A small challenge you can complete in the game
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// A small challenge you can complete in the game
 pub struct Achievement {
     /// Whether or not this achievement has been completed
     pub achieved: bool,
@@ -815,9 +815,9 @@ pub struct Achievement {
     pub progress: i64,
 }
 
+/// Contains all the items & monsters you have found in the scrapbook
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// Contains all the items & monsters you have found in the scrapbook
 pub struct ScrapBook {
     /// All the items, that this player has already collected. To check if an
     /// item is in this, you should call `equipment_ident()` on an item and see
@@ -872,9 +872,9 @@ impl ScrapBook {
     }
 }
 
+/// The identification of items in the scrapbook
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The identification of items in the scrapbook
 pub struct EquipmentIdent {
     /// The class the item has and thus the wearer must have
     pub class: Option<Class>,

--- a/src/response.rs
+++ b/src/response.rs
@@ -5,7 +5,6 @@ use log::{error, trace, warn};
 
 use crate::error::SFError;
 
-#[ouroboros::self_referencing]
 /// A bunch of new information about the state of the server and/or the
 /// player
 ///
@@ -16,6 +15,7 @@ use crate::error::SFError;
 // Technically we could do this safely with an iterator, that parses on demand,
 // but send_command() needs to access specific response keys to keep the session
 // running, which means a HashMap needs to be constructed no matter what
+#[ouroboros::self_referencing]
 pub struct Response {
     body: String,
     #[borrows(body)]
@@ -235,11 +235,11 @@ impl Response {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-#[allow(clippy::module_name_repetitions)]
 /// This is the raw &str, that the server send as a value to some key. This
 /// often requires extra conversions/parsing to use practically, so we associate
 /// the most common parsing functions as methods to this data.
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::module_name_repetitions)]
 pub struct ResponseVal<'a> {
     value: &'a str,
     sub_key: &'a str,

--- a/src/session.rs
+++ b/src/session.rs
@@ -20,9 +20,9 @@ use crate::{
 #[allow(deprecated)]
 pub use crate::{misc::decrypt_url, response::*};
 
+/// The session, that manages the server communication for a character
 #[derive(Debug, Clone)]
 #[allow(clippy::struct_field_names)]
-/// The session, that manages the server communication for a character
 pub struct Session {
     /// The information necessary to log in
     login_data: LoginData,
@@ -43,9 +43,9 @@ pub struct Session {
     options: ConnectionOptions,
 }
 
+/// The password of a character, hashed in the way, that the server expects
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-/// The password of a character, hashed in the way, that the server expects
 pub struct PWHash(String);
 
 impl PWHash {
@@ -383,8 +383,8 @@ impl Session {
         Ok(Session::new_full(ld, client, options, url))
     }
 
-    #[must_use]
     /// The username of the character, that this session is responsible for
+    #[must_use]
     pub fn username(&self) -> &str {
         match &self.login_data {
             LoginData::Basic { username, .. } => username,
@@ -396,7 +396,6 @@ impl Session {
         }
     }
 
-    #[cfg(feature = "sso")]
     /// Retrieves new sso credentials from its sf account. If the account
     /// already has new creds stored, these are read, otherwise the account will
     /// be logged in again
@@ -406,6 +405,7 @@ impl Session {
     ///   an SSO-Session
     /// - Other errors, depending on if the session is able to renew the
     ///   credentials
+    #[cfg(feature = "sso")]
     pub async fn renew_sso_creds(&mut self) -> Result<(), SFError> {
         let LoginData::SSO {
             account, session, ..
@@ -455,11 +455,11 @@ enum LoginData {
     },
 }
 
-#[derive(Debug, Clone)]
 /// Stores all information necessary to talk to the server. Notably, if you
 /// clone this, instead of creating this multiple times for characters on a
 /// server, this will use the same `reqwest::Client`, which can have slight
 /// benefits to performance
+#[derive(Debug, Clone)]
 pub struct ServerConnection {
     url: url::Url,
     client: Client,
@@ -514,8 +514,8 @@ pub(crate) fn reqwest_client(
     builder.default_headers(headers).build().ok()
 }
 
-#[derive(Debug, Clone)]
 /// Options, that change the behaviour of the communication with the server
+#[derive(Debug, Clone)]
 pub struct ConnectionOptions {
     /// A custom useragent to use, when sending requests to the server
     pub user_agent: Option<String>,
@@ -576,12 +576,12 @@ impl SimpleSession {
         })
     }
 
-    #[cfg(feature = "sso")]
     ///  Creates new `SimpleSession`s, by logging in the S&S SSO account and
     /// returning all the characters associated with the account
     ///
     /// # Errors
     /// Have a look at `send_command` for a full list of possible errors
+    #[cfg(feature = "sso")]
     pub async fn login_sf_account(
         username: &str,
         password: &str,


### PR DESCRIPTION
The previous placement of doc comments was inconsistent in some places, often appearing below `#[derive(...)]` macros:

```rust
#[derive(Debug, Clone)]
/// Doc comment here
pub struct MyStruct {}
```

This PR moves all such documentation comments to be above the attributes:

```rust
/// Doc comment here
#[derive(Debug, Clone)]
pub struct MyStruct {}
```